### PR TITLE
166980308 CRUD operations for articles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1796,6 +1796,11 @@
         "function-bind": "^1.1.1"
       }
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -2023,6 +2028,11 @@
         "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+        },
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
@@ -2049,6 +2059,11 @@
         "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+        },
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -3025,9 +3040,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
     "core-js-compat": {
       "version": "3.1.4",
@@ -3624,6 +3639,16 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
       "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg=="
     },
+    "draft-js": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.10.5.tgz",
+      "integrity": "sha512-LE6jSCV9nkPhfVX2ggcRLA4FKs6zWq9ceuO/88BpXdNCS7mjRTgs0NsV6piUCJX9YxMsB9An33wnkMmU2sD2Zg==",
+      "requires": {
+        "fbjs": "^0.8.15",
+        "immutable": "~3.7.4",
+        "object-assign": "^4.1.0"
+      }
+    },
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -3690,6 +3715,14 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -4619,6 +4652,20 @@
         "bser": "^2.0.0"
       }
     },
+    "fbjs": {
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "requires": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      }
+    },
     "fetch-mock": {
       "version": "7.3.6",
       "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-7.3.6.tgz",
@@ -4631,6 +4678,11 @@
         "whatwg-url": "^6.5.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+        },
         "path-to-regexp": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
@@ -4908,7 +4960,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4932,13 +4985,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4955,19 +5010,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5098,7 +5156,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5112,6 +5171,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5128,6 +5188,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5136,13 +5197,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5163,6 +5226,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5251,7 +5315,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5265,6 +5330,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5360,7 +5426,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5402,6 +5469,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5423,6 +5491,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5471,13 +5540,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6139,7 +6210,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -6176,6 +6246,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
+    },
+    "immutable": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+      "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
     },
     "import-fresh": {
       "version": "3.1.0",
@@ -6656,6 +6731,26 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -9430,6 +9525,14 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -10334,8 +10437,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",
@@ -10959,8 +11061,7 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
       "version": "1.1.1",
@@ -12122,6 +12223,11 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "ua-parser-js": {
+      "version": "0.7.20",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
+      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
+    },
     "uglify-js": {
       "version": "3.4.10",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
@@ -12831,6 +12937,11 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "fetch-mock": "^7.3.3",
     "materialize-css": "^1.0.0",
     "node-fetch": "^2.6.0",
+    "draft-js": "^0.10.5",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/src/App.spec.js
+++ b/src/App.spec.js
@@ -2,14 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 
+import { storeFactory } from "./testutils/";
 import App from "./App";
-import { storeFactory } from "./testutils";
-
-
-const store = storeFactory();
 
 it("renders without crashing", () => {
   const div = document.createElement("div");
+  const store = storeFactory({});
   ReactDOM.render(
     <Provider {...{ store }}>
       <App />

--- a/src/Helpers/axios.js
+++ b/src/Helpers/axios.js
@@ -14,3 +14,12 @@ export const apiCalls = (
   const resolvedUrl = heroku ? baseUrl + url : url;
   return axiosMethod(resolvedUrl, data, { headers: headers });
 };
+
+export const deleteCalls = (method, url, token) => {
+  const headers = {
+    "Content-Type": "application/json",
+    Authorization: "Bearer " + token
+  };
+  const axiosMethod = axios[method];
+  return axiosMethod(baseUrl + url, { headers: headers });
+};

--- a/src/components/Article/ArticleCard.js
+++ b/src/components/Article/ArticleCard.js
@@ -1,0 +1,53 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import "./styles/articles.css";
+
+const ArticleCard = article => {
+  const {
+    id,
+    title,
+    slug,
+    description,
+    image_url,
+    avg_rating,
+    read_time
+  } = article.article;
+  return (
+    <div className="container" data-test="card-test">
+      <div className="row" id={slug} key={id}>
+        <div className="col m12">
+          <div className="card">
+            <div className="card-image waves-effect waves-block waves-light">
+              <img width="20" height="400" src={image_url} alt="None to show" />
+            </div>
+            <div className="card-content align-right">
+              <h3 className="article-title">
+                <span>{title}</span>
+              </h3>
+              <p className="article-desc">
+                <span>{description}</span>
+              </p>
+              <div className="right-align">
+                <i>
+                  <span>{read_time}</span>
+                  <br />
+                  <span>Rating: {avg_rating}</span>
+                </i>
+              </div>
+            </div>
+            <div className="card-action">
+              <Link
+                className="waves-effect waves-light btn"
+                to={`/articles/${slug}`}
+              >
+                Read Article
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ArticleCard;

--- a/src/components/Article/ArticleEditor.js
+++ b/src/components/Article/ArticleEditor.js
@@ -1,0 +1,251 @@
+import React from "react";
+import {
+  Editor,
+  EditorState,
+  RichUtils,
+  getDefaultKeyBinding,
+  convertToRaw,
+  convertFromRaw,
+  convertFromHTML,
+  ContentState
+} from "draft-js";
+import "./styles/RichEditor.css";
+
+export const convert = content => {
+  let result;
+  try {
+    const data = JSON.parse(content);
+    result = convertFromRaw(data);
+  } catch (err) {
+    const html = `<p>${content}</p>`;
+    const blocksFromHTML = convertFromHTML(html);
+    const state = ContentState.createFromBlockArray(
+      blocksFromHTML.contentBlocks,
+      blocksFromHTML.entityMap
+    );
+    result = state;
+  }
+
+  return result;
+};
+
+export class ArticleEditor extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      editorState: props.body
+        ? EditorState.createWithContent(convert(props.body))
+        : EditorState.createEmpty()
+    };
+    this.focus = () => this.refs.editor.focus();
+    this.onChange = this.onChange.bind(this);
+    this.handleKeyCommand = this._handleKeyCommand.bind(this);
+    this.mapKeyToEditorCommand = this._mapKeyToEditorCommand.bind(this);
+    this.toggleBlockType = this._toggleBlockType.bind(this);
+    this.toggleInlineStyle = this._toggleInlineStyle.bind(this);
+  }
+  _handleKeyCommand(command, editorState) {
+    const newState = RichUtils.handleKeyCommand(editorState, command);
+    if (newState) {
+      this.onChange(newState);
+      return true;
+    }
+    return false;
+  }
+  _mapKeyToEditorCommand(e) {
+    if (e.keyCode === 9 /* TAB */) {
+      const newEditorState = RichUtils.onTab(
+        e,
+        this.state.editorState,
+        4 /* maxDepth */
+      );
+      if (newEditorState !== this.state.editorState) {
+        this.onChange(newEditorState);
+      }
+      return;
+    }
+    return getDefaultKeyBinding(e);
+  }
+  _toggleBlockType(blockType) {
+    this.onChange(RichUtils.toggleBlockType(this.state.editorState, blockType));
+  }
+  _toggleInlineStyle(inlineStyle) {
+    this.onChange(
+      RichUtils.toggleInlineStyle(this.state.editorState, inlineStyle)
+    );
+  }
+
+  onChange(editorState) {
+    const { getDraftJSContent, edit } = this.props;
+    if (edit) {
+      this.setState({ editorState });
+      const contentState = editorState.getCurrentContent();
+      getDraftJSContent(JSON.stringify(convertToRaw(contentState)));
+    }
+  }
+
+  render() {
+    const { editorState } = this.state;
+    const { edit } = this.props;
+    // If the user changes block type before entering any text, we can
+    // either style the placeholder or hide it. Let's just hide it now.
+    let className = "RichEditor-editor";
+    var contentState = editorState.getCurrentContent();
+    if (!contentState.hasText()) {
+      if (
+        contentState
+          .getBlockMap()
+          .first()
+          .getType() !== "unstyled"
+      ) {
+        className += " RichEditor-hidePlaceholder";
+      }
+    }
+    return (
+      <div>
+        <div
+          style={{
+            height: 30
+          }}
+        />
+        <div className="RichEditor-root">
+          {edit && (
+            <div data-test="article-edit-controls">
+              <BlockStyleControls
+                editorState={editorState}
+                onToggle={this.toggleBlockType}
+              />
+              <InlineStyleControls
+                editorState={editorState}
+                onToggle={this.toggleInlineStyle}
+              />
+            </div>
+          )}
+          <div
+            className={className}
+            data-test="editor-container"
+            onClick={this.focus}
+          >
+            <Editor
+              blockStyleFn={getBlockStyle}
+              customStyleMap={styleMap}
+              editorState={editorState}
+              handleKeyCommand={this.handleKeyCommand}
+              keyBindingFn={this.mapKeyToEditorCommand}
+              onChange={this.onChange}
+              placeholder="Tell a story..."
+              ref="editor"
+              readOnly={!Boolean(edit)}
+              spellCheck={true}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+// Custom overrides for "code" style.
+const styleMap = {
+  CODE: {
+    backgroundColor: "rgba(0, 0, 0, 0.05)",
+    fontFamily: '"Inconsolata", "Menlo", "Consolas", monospace',
+    fontSize: 16,
+    padding: 2
+  }
+};
+
+export function getBlockStyle(block) {
+  switch (block.getType()) {
+    case "blockquote":
+      return "RichEditor-blockquote";
+    default:
+      return null;
+  }
+}
+
+export class StyleButton extends React.Component {
+  constructor() {
+    super();
+    this.onToggle = e => {
+      e.preventDefault();
+      this.props.onToggle(this.props.style);
+    };
+  }
+  render() {
+    let className = "RichEditor-styleButton";
+    if (this.props.active) {
+      className += " RichEditor-activeButton";
+    }
+    return (
+      <span
+        data-test="single-style-button"
+        className={className}
+        onMouseDown={this.onToggle}
+      >
+        {this.props.label}
+      </span>
+    );
+  }
+}
+
+const BLOCK_TYPES = [
+  { label: "H1", style: "header-one" },
+  { label: "H2", style: "header-two" },
+  { label: "H3", style: "header-three" },
+  { label: "H4", style: "header-four" },
+  { label: "H5", style: "header-five" },
+  { label: "H6", style: "header-six" },
+  { label: "Blockquote", style: "blockquote" },
+  { label: "UL", style: "unordered-list-item" },
+  { label: "OL", style: "ordered-list-item" },
+  { label: "Code Block", style: "code-block" }
+];
+
+export const BlockStyleControls = props => {
+  const { editorState } = props;
+  const selection = editorState.getSelection();
+  const blockType = editorState
+    .getCurrentContent()
+    .getBlockForKey(selection.getStartKey())
+    .getType();
+  return (
+    <div className="RichEditor-controls">
+      {BLOCK_TYPES.map(type => (
+        <StyleButton
+          key={type.label}
+          active={type.style === blockType}
+          label={type.label}
+          onToggle={props.onToggle}
+          style={type.style}
+        />
+      ))}
+    </div>
+  );
+};
+var INLINE_STYLES = [
+  { label: "Bold", style: "BOLD" },
+  { label: "Italic", style: "ITALIC" },
+  { label: "Underline", style: "UNDERLINE" },
+  { label: "Monospace", style: "CODE" }
+];
+
+export const InlineStyleControls = props => {
+  const currentStyle = props.editorState.getCurrentInlineStyle();
+
+  return (
+    <div className="RichEditor-controls">
+      {INLINE_STYLES.map(type => (
+        <StyleButton
+          key={type.label}
+          active={currentStyle.has(type.style)}
+          label={type.label}
+          onToggle={props.onToggle}
+          style={type.style}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default ArticleEditor;

--- a/src/components/Article/__tests__/articleCard.spec.js
+++ b/src/components/Article/__tests__/articleCard.spec.js
@@ -1,0 +1,29 @@
+import React from "react";
+import { shallow } from "enzyme";
+import ArticleCard from "../ArticleCard";
+import { findByTestAttr } from "../../../testutils";
+
+describe("<Notfound />", () => {
+  test("should render Notfound without errors", () => {
+    const article = {
+      id: 10,
+      body: "This is all but an article",
+      description: "Artilces are not the best things to add",
+      title: "Super fly",
+      image_url: "image_url",
+      author: {
+        username: "Kimaiyo",
+        bio: "",
+        image: ""
+      },
+      slug: "dragon-rider",
+      avg_rating: 0,
+      tags: [],
+      read_time: "1 min read"
+    };
+    const wrapper = shallow(<ArticleCard {...{ article }} />);
+    expect(wrapper).toBeTruthy();
+    const card = findByTestAttr(wrapper, "card-test");
+    expect(card.length).toBe(1);
+  });
+});

--- a/src/components/Article/__tests__/articleEditor.spec.js
+++ b/src/components/Article/__tests__/articleEditor.spec.js
@@ -1,0 +1,195 @@
+import React from "react";
+import { shallow } from "enzyme";
+import * as Draft from "draft-js";
+
+import { findByTestAttr } from "../../../testutils";
+
+import {
+  ArticleEditor,
+  convert,
+  getBlockStyle,
+  StyleButton,
+  BlockStyleControls,
+  InlineStyleControls
+} from "../ArticleEditor";
+
+const { EditorState } = Draft;
+
+const testRender = type => {
+  const content = EditorState.createWithContent(convert("Hello Here"));
+  let wrap;
+  let num;
+  if (type === "block") {
+    wrap = shallow(<BlockStyleControls editorState={content} />);
+    num = 10;
+  } else {
+    wrap = shallow(<InlineStyleControls editorState={content} />);
+    num = 4;
+  }
+  expect(wrap.find(StyleButton).length).toBe(num);
+};
+
+const setUp = (props = {}) => shallow(<ArticleEditor {...props} />);
+const body = "Lets all breathe fire and fly";
+describe("test convert fn", () => {
+  test("should return a Draftjs p tag when content comes as a string", () => {
+    expect(JSON.stringify(convert(body).blockMap)).toContain(body);
+  });
+  test("should convert Draftjs Stringified content to draftjs", () => {
+    const bodyparam = JSON.stringify(convert(body));
+    const parsedcontent = convert(bodyparam);
+    expect(JSON.stringify(parsedcontent)).toContain(body);
+  });
+});
+
+describe("<ArticleEditor /> editor on preview", () => {
+  test("should render <ArticleEditor /> with the draftjs content as the editorState", () => {
+    const draftjsBody = JSON.stringify(convert(body));
+    const wrapper = setUp({ body: draftjsBody });
+    const editorState = wrapper.state().editorState;
+    expect(JSON.stringify(editorState)).toContain(body);
+  });
+  test("should render <ArticleEditor /> with the draftjs blank content as the editorState", () => {
+    const wrapper = setUp({});
+
+    const editorState = wrapper.state().editorState;
+    expect(JSON.stringify(editorState)).toContain(JSON.stringify("text"));
+  });
+});
+
+describe("<Article /> on edit mode", () => {
+  test("should render editing controls without error", () => {
+    const wrapper = setUp({ edit: true });
+    const edittingContainer = findByTestAttr(wrapper, "article-edit-controls");
+    expect(edittingContainer.exists()).toBe(true);
+  });
+});
+
+describe("getBlockStyle fn() tests", () => {
+  const getTypeFunction = type => ({
+    getType: () => type
+  });
+  test("should return special classname for blockquote type", () => {
+    const block = {
+      ...getTypeFunction("blockquote")
+    };
+    const blockStyle = getBlockStyle(block);
+    expect(blockStyle).toEqual("RichEditor-blockquote");
+  });
+  test("should return null for other types", () => {
+    const block = {
+      ...getTypeFunction("h3")
+    };
+    const blockStyle = getBlockStyle(block);
+    expect(blockStyle).toBe(null);
+  });
+});
+
+describe("<StyleButton />", () => {
+  const stylesButton = (props = {}) => shallow(<StyleButton {...props} />);
+  test("should render without error ", () => {
+    const stylesButtonWrapper = stylesButton();
+    const button = findByTestAttr(stylesButtonWrapper, "single-style-button");
+    expect(button.props().className).toBe("RichEditor-styleButton");
+  });
+  test("should add the active class when active prop is true", () => {
+    const stylesButtonWrapper = stylesButton({ active: true });
+    const button = findByTestAttr(stylesButtonWrapper, "single-style-button");
+    expect(button.props().className).toBe(
+      "RichEditor-styleButton RichEditor-activeButton"
+    );
+  });
+  test("should call onToggle with props.style", () => {
+    const onToggle = jest.fn();
+    const style = "header-one";
+    const stylesButtonWrapper = stylesButton({ onToggle, style });
+    const button = findByTestAttr(stylesButtonWrapper, "single-style-button");
+    button.simulate("mouseDown", {
+      preventDefault: jest.fn()
+    });
+
+    expect(onToggle).toBeCalledWith(style);
+  });
+});
+
+describe("<BlockStyleControls /> tests", () => {
+  test("should render without errors", () => {
+    testRender("block");
+  });
+});
+
+describe("<InlineStyleControls /> tests", () => {
+  test("should render InlineStyleControls without error", () => {
+    testRender("inline");
+  });
+});
+
+describe("<ArticleEditor /> functions", () => {
+  const content = EditorState.createWithContent(convert("Hello Here"));
+  const getDraftJSContent = jest.fn();
+  const newContent = EditorState.createWithContent(
+    convert("Hello Here New State")
+  );
+  const wrap = shallow(
+    <ArticleEditor
+      edit={true}
+      editorState={content}
+      getDraftJSContent={getDraftJSContent}
+    />
+  );
+
+  const draftFunc = type => {
+    Draft.RichUtils.onTab = jest.fn(() => newContent);
+    if (type === "inline") {
+      Draft.RichUtils.toggleInlineStyle = jest.fn(() => content);
+    } else {
+      Draft.RichUtils.toggleBlockType = jest.fn(() => content);
+    }
+  };
+
+  test("should call getDraftJSContent when onChange is called", () => {
+    wrap.instance().onChange(newContent);
+    expect(getDraftJSContent).toHaveBeenCalled();
+  });
+
+  test(" _handleKeyCommand should return true if newState returns content", () => {
+    Draft.RichUtils.handleKeyCommand = jest.fn(() => content);
+    const wrapper = shallow(<ArticleEditor />);
+    expect(wrapper.instance()._handleKeyCommand("command", content)).toBe(true);
+  });
+  test(" _handleKeyCommand should return false if newState is false", () => {
+    Draft.RichUtils.handleKeyCommand = jest.fn(() => false);
+    const wrapper = shallow(<ArticleEditor />);
+    expect(wrapper.instance()._handleKeyCommand("command", "content")).toBe(
+      false
+    );
+  });
+  test("_mapKeyToEditorCommand should be called with", () => {
+    Draft.RichUtils.onTab = jest.fn(() => newContent);
+
+    wrap.instance()._mapKeyToEditorCommand({
+      keyCode: 9
+    });
+    expect(getDraftJSContent).toHaveBeenCalled();
+  });
+  test("getDefaultKeyBinding should be called when _mapKeyToEditorCommand", () => {
+    const getDraftJSContent = jest.fn();
+    Draft.RichUtils.onTab = jest.fn(() => newContent);
+    wrap.instance()._mapKeyToEditorCommand({
+      keyCode: 12
+    });
+    expect(getDraftJSContent).not.toHaveBeenCalled();
+  });
+  test("_toggleBlockType should call this.onChange", () => {
+    draftFunc("block");
+
+    wrap.instance()._toggleBlockType(content);
+    expect(Draft.RichUtils.toggleBlockType).toHaveBeenCalled();
+  });
+  test("_toggleInlineStyle should call this.onChange", () => {
+    draftFunc("inline");
+
+    wrap.instance()._toggleInlineStyle(content);
+    expect(Draft.RichUtils.toggleInlineStyle).toHaveBeenCalled();
+  });
+});

--- a/src/components/Article/styles/RichEditor.css
+++ b/src/components/Article/styles/RichEditor.css
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+ *
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only. Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+.RichEditor-root {
+  background: #fff;
+
+  font-family: "Georgia", serif;
+  font-size: 14px;
+  padding: 15px;
+  width: 100%;
+}
+
+.RichEditor-editor {
+  border-top: 1px solid #ddd;
+  cursor: text;
+  font-size: 16px;
+  margin-top: 10px;
+}
+
+.RichEditor-editor .public-DraftEditorPlaceholder-root,
+.RichEditor-editor .public-DraftEditor-content {
+  margin: 0 -15px -15px;
+  padding: 15px;
+}
+
+.RichEditor-editor .public-DraftEditor-content {
+  min-height: 100px;
+}
+
+.RichEditor-hidePlaceholder .public-DraftEditorPlaceholder-root {
+  display: none;
+}
+
+.RichEditor-editor .RichEditor-blockquote {
+  border-left: 5px solid #eee;
+  color: #666;
+  font-family: "Hoefler Text", "Georgia", serif;
+  font-style: italic;
+  margin: 16px 0;
+  padding: 10px 20px;
+}
+
+.RichEditor-editor .public-DraftStyleDefault-pre {
+  background-color: rgba(0, 0, 0, 0.05);
+  font-family: "Inconsolata", "Menlo", "Consolas", monospace;
+  font-size: 16px;
+  padding: 20px;
+}
+
+.RichEditor-controls {
+  font-family: "Helvetica", sans-serif;
+  font-size: 14px;
+  margin-bottom: 5px;
+  user-select: none;
+}
+
+.RichEditor-styleButton {
+  color: #999;
+  cursor: pointer;
+  margin-right: 16px;
+  padding: 2px 0;
+  display: inline-block;
+}
+
+.RichEditor-activeButton {
+  color: #5890ff;
+}

--- a/src/components/Article/styles/articles.css
+++ b/src/components/Article/styles/articles.css
@@ -1,0 +1,50 @@
+.article-title {
+  font-family: "Times New Roman";
+  font-weight: lighter;
+  padding: 10px;
+}
+
+.article-desc {
+  font-family: "Lucida Sans", "Lucida Sans Regular", "Lucida Grande",
+    "Lucida Sans Unicode";
+  padding: 10px;
+}
+
+.article-author {
+  margin: 1em;
+}
+
+.article-author-name {
+  padding: 1em;
+  color: #333;
+  font-weight: lighter;
+  margin-right: 1rem;
+  font-size: 15px;
+}
+.loader {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  margin-top: -50px;
+  margin-left: -100px;
+}
+
+.avatar {
+  vertical-align: middle;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+}
+
+.user-buttons {
+  margin: 3em;
+}
+
+.delete-button {
+  margin: 2em;
+}
+
+.read_time {
+  font-weight: lighter;
+  margin-top: 2em;
+}

--- a/src/containers/Snackbars/__tests__/snackbarContainer.spec.js
+++ b/src/containers/Snackbars/__tests__/snackbarContainer.spec.js
@@ -46,8 +46,7 @@ describe("Test snackBarComponent", () => {
     expect(wrapper.find(Snackbar).length).toBe(2);
   });
   test("should call onDismiss with the ID", () => {
-    const DismissMessage = id => {
-    };
+    const DismissMessage = id => {};
     const wrapper = setUpUnconnectedSnackbar({ DismissMessage });
     const firstSnackbar = wrapper.find(Snackbar).first();
     const snackbarprops = firstSnackbar.props();

--- a/src/containers/articles/Articles.js
+++ b/src/containers/articles/Articles.js
@@ -1,0 +1,34 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import ArticleCard from "../../components/Article/ArticleCard";
+import { getArticles } from "../../redux/actions/articleActions";
+
+export class Articles extends Component {
+  componentDidMount() {
+    this.props.getArticles();
+  }
+  render() {
+    return (
+      <div data-test="test-article">
+        <br />
+        <div className="row">
+          <div className="col s9">
+            {this.props.articles.map(article => (
+              <div>
+                <ArticleCard article={article} />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  articles: state.articles.articles
+});
+export default connect(
+  mapStateToProps,
+  { getArticles }
+)(Articles);

--- a/src/containers/articles/EditArticle.js
+++ b/src/containers/articles/EditArticle.js
@@ -1,0 +1,122 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { withRouter } from "react-router-dom";
+import { updateArticle, viewArticle } from "../../redux/actions/articleActions";
+import ArticleEditor from "../../components/Article/ArticleEditor";
+import { ShowMessage } from "../../redux/actions/SnackBarAction";
+import Imageupload from "../../components/Imageupload/Imageupload";
+
+export class EditArticle extends Component {
+  constructor(props) {
+    super(props);
+    const { article } = this.props;
+    this.state = {
+      title: article.title,
+      description: article.description,
+      image: article.image_url,
+      body: article.body
+    };
+
+    this.chipsRef = React.createRef();
+    this.handleChanges = key => {
+      return event => {
+        this.setState({
+          [key]: event.target.value
+        });
+      };
+    };
+    this.handleBody = body => {
+      this.setState({
+        body
+      });
+    };
+
+    this.handleImage = image => {
+      this.setState({
+        image
+      });
+    };
+
+    this.UpdateArticle = event => {
+      event.preventDefault();
+
+      const token = localStorage.getItem("token");
+      const { ShowMessage, updateArticle, history } = this.props;
+      const articleData = {
+        title: this.state.title,
+        description: this.state.description,
+        body: this.state.body,
+        image_url: this.state.image
+      };
+
+      return updateArticle(article.slug, articleData, token).then(data => {
+        history.push(`/articles/${data.slug}`);
+        ShowMessage("Successfully updated your article");
+      });
+    };
+  }
+
+  componentDidMount() {
+    this.props.viewArticle(this.props.match.params.slug);
+  }
+
+  render() {
+    return (
+      <div className="container" data-test="edit-test">
+        <br />
+        <div className="card">
+          <div className="card-content">
+            <br />
+            <form onSubmit={this.UpdateArticle}>
+              <div className="row">
+                <div>
+                  <input
+                    data-test="edit-input"
+                    id="title"
+                    type="text"
+                    className="validate"
+                    value={this.state.title}
+                    onChange={this.handleChanges("title")}
+                  />
+                </div>
+                <div className="input-field">
+                  <textarea
+                    id="description"
+                    className="materialize-textarea"
+                    value={this.state.description}
+                    onChange={this.handleChanges("description")}
+                  />
+                  <Imageupload uploadedImageUrl={this.handleImage} />
+                </div>
+                <ArticleEditor
+                  edit={true}
+                  body={this.state.body}
+                  getDraftJSContent={this.handleBody}
+                />
+                <br />
+                <button
+                  className="btn waves-effect waves-light"
+                  type="submit"
+                  name="action"
+                >
+                  Save
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  article: state.articles.article
+});
+
+export default withRouter(
+  connect(
+    mapStateToProps,
+    { updateArticle, viewArticle, ShowMessage }
+  )(EditArticle)
+);

--- a/src/containers/articles/PostArticle.js
+++ b/src/containers/articles/PostArticle.js
@@ -1,0 +1,149 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { withRouter } from "react-router-dom";
+import { postArticle } from "../../redux/actions/articleActions";
+import ArticleEditor from "../../components/Article/ArticleEditor";
+import { ShowMessage } from "../../redux/actions/SnackBarAction";
+import Imageupload from "../../components/Imageupload/Imageupload";
+
+export class PostArticle extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      title: "",
+      description: "",
+      image: "",
+      body: ""
+    };
+
+    this.chipsRef = React.createRef();
+    this.handleInputs = prop => {
+      return event => {
+        this.setState({
+          [prop]: event.target.value
+        });
+      };
+    };
+    this.handleBody = body => {
+      this.setState({
+        body
+      });
+    };
+
+    this.handleImage = image => {
+      this.setState({
+        image
+      });
+    };
+  }
+
+  createArticle = event => {
+    const { ShowMessage } = this.props;
+    const token = localStorage.getItem("token");
+    event.preventDefault();
+    const article = {
+      article: {
+        title: this.state.title,
+        description: this.state.description,
+        body: this.state.body,
+        image_url: this.state.image,
+        tags: this.chipsRef.current
+          ? this.chipsRef.current.M_Chips.chipsData.map(({ tag }) => tag)
+          : []
+      }
+    };
+
+    return this.props
+      .postArticle(article, token)
+      .then(article => {
+        this.props.history.push(`/articles/${article.slug}`);
+        ShowMessage("Article Successfully created");
+      })
+      .catch(err => {
+        const { status } = err.response;
+        if (status === 500) {
+          ShowMessage({
+            message: "Api Server error 500. Try sending the request again",
+            type: "error"
+          });
+        }
+        if (status === 400) {
+          const { title, body, description } = err.response.data.errors;
+          if (title) {
+            ShowMessage({
+              message: title[0] + "=> title",
+              type: "error"
+            });
+          } else if (description) {
+            ShowMessage({
+              message: description[0],
+              type: "error"
+            });
+          } else if (body) {
+            ShowMessage({
+              message: body[0],
+              type: "error"
+            });
+          }
+        }
+      });
+  };
+
+  render() {
+    return (
+      <div className="container">
+        <br />
+        <form onSubmit={this.createArticle}>
+          <div className="row">
+            <div data-test="post-test">
+              <input
+                data-test="title-input"
+                placeholder="Enter Article Title"
+                id="title"
+                type="text"
+                className="validate"
+                value={this.state.title}
+                onChange={this.handleInputs("title")}
+              />
+            </div>
+            <div className="input-field">
+              <textarea
+                id="description"
+                className="materialize-textarea"
+                placeholder="Enter Article Description"
+                value={this.state.description}
+                onChange={this.handleInputs("description")}
+              />
+              <Imageupload uploadedImageUrl={this.handleImage} />
+            </div>
+            <ArticleEditor edit={true} getDraftJSContent={this.handleBody} />
+            <br />
+            <div className="chips" ref={this.chipsRef}>
+              <input
+                className="custom-class"
+                onChange={this.handleChips}
+                placeholder="Tags"
+              />
+            </div>
+            <br />
+            <button
+              className="btn waves-effect waves-light"
+              type="submit"
+              name="action"
+            >
+              Publish
+              <i className="material-icons right">send</i>
+            </button>
+          </div>
+        </form>
+      </div>
+    );
+  }
+}
+
+export default withRouter(
+  connect(
+    null,
+    { postArticle, ShowMessage }
+  )(PostArticle)
+);

--- a/src/containers/articles/ViewArticle.js
+++ b/src/containers/articles/ViewArticle.js
@@ -1,0 +1,123 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { Link } from "react-router-dom";
+import { viewArticle, deleteArticle } from "../../redux/actions/articleActions";
+import ArticleEditor from "../../components/Article/ArticleEditor";
+
+import "../../components/Article/styles/articles.css";
+
+export class ViewArticle extends Component {
+  componentDidMount() {
+    this.props.viewArticle(this.props.match.params.slug);
+  }
+
+  handleDelete = slug => () => {
+    const { deleteArticle } = this.props;
+    const token = localStorage.getItem("token");
+    return deleteArticle(slug, token).then(data => {
+      this.props.history.push(`/`);
+    });
+  };
+
+  render() {
+    const { article } = this.props;
+    const user = localStorage.getItem("username");
+    return (
+      <div>
+        {article ? (
+          <div data-test="view-test">
+            <div className="container" key={article.id}>
+              <br />
+              <div className="article-title">
+                <h3>{article.title}</h3>
+              </div>
+              <div className="article-author">
+                <img
+                  className="cirlce responsive-img avatar"
+                  src={
+                    article.author.image
+                      ? article.author.image
+                      : "https://cdn1.iconfinder.com/data/icons/robots-avatars-set/354/Robot_avatar___robot_robo_avatar_chatbot_chat-512.png"
+                  }
+                  alt="User Profile pic"
+                />
+                <span className="article-author-name">
+                  {article.author.username}
+                </span>
+                <div className="read_time left-align">
+                  <i>{article.read_time}</i>
+                </div>
+              </div>
+              <div className="row" id={article.slug}>
+                <div className="col m12 m7">
+                  <div className="card">
+                    <div className="card-image waves-effect waves-block waves-light">
+                      <img
+                        className="responsive-img"
+                        width="20"
+                        height="400"
+                        src={article.image_url}
+                        alt="None to show"
+                      />
+                    </div>
+                    <div>
+                      <ArticleEditor
+                        edit={false}
+                        body={article.body}
+                        getDraftJSContent={() => {}}
+                      />
+                    </div>
+                    <div className="user-buttons right-align">
+                      {user === article.author.username ? (
+                        <div>
+                          <Link
+                            className="waves-effect waves-light btn update-button"
+                            to={`/edit/${article.slug}`}
+                          >
+                            Update
+                          </Link>
+                          <button
+                            data-test="delete-button"
+                            className="btn waves-effect waves-light delete-button"
+                            onClick={this.handleDelete(article.slug)}
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div
+            className="preloader-wrapper big active loader"
+            data-test="no-view-test"
+          >
+            <div className="spinner-layer spinner-orange">
+              <div className="circle-clipper left">
+                <div className="circle" />
+              </div>
+              <div className="gap-patch">
+                <div className="circle" />
+              </div>
+              <div className="circle-clipper right">
+                <div className="circle" />
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  article: state.articles.article
+});
+export default connect(
+  mapStateToProps,
+  { viewArticle, deleteArticle }
+)(ViewArticle);

--- a/src/containers/articles/__tests__/articles.spec.js
+++ b/src/containers/articles/__tests__/articles.spec.js
@@ -1,0 +1,33 @@
+import React from "react";
+import { shallow } from "enzyme";
+import renderer from "../../../testutils/renderer";
+
+import { Articles } from "../Articles";
+
+const articles = [
+  {
+    id: 2,
+    title: "This Article is awesome",
+    description: "Best article ever",
+    body: "Glad i am dead to wwokr",
+    image_url: "image_url",
+    author: {
+      username: "Kimaiyo",
+      bio: "",
+      image: ""
+    },
+    slug: "dragon-rider",
+    avg_rating: 0,
+    rating_count: 0,
+    tags: [],
+    read_time: "1 min read"
+  }
+];
+const setup = (props = { articles }, state = null) => {
+  return shallow(<Articles {...props} />);
+};
+
+test("should render Articles page without errors", () => {
+  const wrapper = setup();
+  renderer(wrapper, "test-article");
+});

--- a/src/containers/articles/__tests__/editArticle.spec.js
+++ b/src/containers/articles/__tests__/editArticle.spec.js
@@ -1,0 +1,124 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { MemoryRouter, Route } from "react-router-dom";
+
+import axios from "axios";
+import { storeFactory } from "../../../testutils";
+import renderer from "../../../testutils/renderer";
+import simulator from "../../../testutils/simulator";
+
+import ConnectedEditArticle, { EditArticle } from "../EditArticle";
+
+jest.spyOn(axios, "put");
+
+const article = {
+  author: {
+    username: "Kimaiyo",
+    bio: "",
+    image: ""
+  },
+  title: "dragon rider",
+  description: "Ever wonder how a dragon flies?",
+  body: "Lets all breathe fire and fly",
+  image_url: "image_url",
+  tags: [],
+  read_time: "1 min read",
+  slug: "dragon-rider",
+  avg_rating: 0,
+  rating_count: 0
+};
+const setup = (props = { article }) => {
+  return shallow(<EditArticle {...props} />);
+};
+
+describe("Tests for Editing an article", () => {
+  test("should render page without errors", () => {
+    const wrapper = setup();
+    renderer(wrapper, "edit-test");
+  });
+
+  test("should UpdateArticle successfully", () => {
+    const updateArticle = jest.fn(() => Promise.resolve({}));
+    const history = {
+      push: jest.fn()
+    };
+
+    axios.put.mockImplementation(() =>
+      Promise.resolve({
+        slug: "article-slug"
+      })
+    );
+    const wrapper = setup({ article, updateArticle, history });
+
+    wrapper
+      .instance()
+      .UpdateArticle({
+        preventDefault: jest.fn()
+      })
+      .then(() => {
+        expect(updateArticle).toHaveBeenCalled();
+      });
+  });
+
+  test("should call componentDidMount and pass slug to the viewArticlefn", () => {
+    const viewArticle = jest.fn();
+    const wrapper = shallow(
+      <MemoryRouter initialEntries={["/edit/awesomearticle"]}>
+        <Route
+          path="/edit/:slug"
+          render={props => (
+            <EditArticle {...props} {...{ viewArticle, article }} />
+          )}
+        />
+      </MemoryRouter>
+    )
+      .dive()
+      .dive()
+      .dive()
+      .dive()
+      .dive()
+      .dive();
+    wrapper.instance().componentDidMount();
+    expect(viewArticle).toHaveBeenCalledWith("awesomearticle");
+  });
+
+  test("should update state with article returned from redux", () => {
+    const store = storeFactory({
+      articles: {
+        article
+      }
+    });
+
+    const wrapper = shallow(
+      <MemoryRouter initialEntries={["/edit/awesomearticle"]}>
+        <Route
+          path="/edit/:slug"
+          render={props => (
+            <ConnectedEditArticle {...props} {...{ store, article }} />
+          )}
+        />
+      </MemoryRouter>
+    )
+      .dive()
+      .dive()
+      .dive()
+      .dive()
+      .dive()
+      .dive()
+      .dive()
+      .dive()
+      .dive()
+      .dive();
+    expect(wrapper.state()).toEqual({
+      body: "Lets all breathe fire and fly",
+      description: "Ever wonder how a dragon flies?",
+      image: "image_url",
+      title: "dragon rider"
+    });
+  });
+
+  test("check title state of edited article ", () => {
+    const wrapper = setup();
+    simulator(wrapper, "edit-input");
+  });
+});

--- a/src/containers/articles/__tests__/postArticle.spec.js
+++ b/src/containers/articles/__tests__/postArticle.spec.js
@@ -1,0 +1,131 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import axios from "axios";
+import { findByTestAttr } from "../../../testutils";
+
+import renderer from "../../../testutils/renderer";
+import { PostArticle } from "../PostArticle";
+
+jest.spyOn(axios, "post");
+
+const setup = (props = {}) => {
+  return shallow(<PostArticle {...props} />);
+};
+
+describe("Tests for Posting an article", () => {
+  test("should render page without errors", () => {
+    const wrapper = setup();
+
+    renderer(wrapper, "post-test");
+  });
+
+  test("check title state of new article ", () => {
+    const wrapper = setup();
+    const titleinput = findByTestAttr(wrapper, "title-input");
+    titleinput.simulate("change", {
+      target: {
+        value: "Kimaiyo's Article"
+      }
+    });
+
+    expect(findByTestAttr(wrapper, "title-input").prop("value")).toBe(
+      "Kimaiyo's Article"
+    );
+  });
+  test("should call showMessage with success when a user creates article successfully", () => {
+    const ShowMessage = jest.fn();
+    const postArticle = jest.fn(() =>
+      Promise.resolve({
+        slug: "article-1"
+      })
+    );
+    const history = {
+      push: jest.fn()
+    };
+    axios.post.mockImplementation(() =>
+      Promise.resolve({
+        slug: "article-1"
+      })
+    );
+    const wrapper = setup({ ShowMessage, postArticle, history });
+    wrapper
+      .instance()
+      .createArticle({
+        preventDefault: jest.fn()
+      })
+      .then(() => {
+        expect(ShowMessage).toHaveBeenCalled();
+      });
+  });
+  test("should setBody in state after calling handleBody", () => {
+    const wrapper = setup();
+    wrapper.instance().handleBody("New error");
+    expect(wrapper.state().body).toBe("New error");
+  });
+  test("should call ShowMessage when error code is 500  ", () => {
+    const ShowMessage = jest.fn();
+    const postArticle = jest.fn(() =>
+      Promise.reject({
+        response: {
+          status: 500
+        }
+      })
+    );
+    const history = {
+      push: jest.fn()
+    };
+    axios.post.mockImplementation(() =>
+      Promise.resolve({
+        slug: "article-1"
+      })
+    );
+    const wrapper = setup({ ShowMessage, postArticle, history });
+    wrapper
+      .instance()
+      .createArticle({
+        preventDefault: jest.fn()
+      })
+      .then(() => {
+        expect(ShowMessage).toHaveBeenCalledWith({
+          message: "Api Server error 500. Try refreshing the page",
+          type: "error"
+        });
+      });
+  });
+  test("should call ShowMessage with custom message provided when error is not 500", () => {
+    const ShowMessage = jest.fn();
+    const postArticle = jest.fn(() =>
+      Promise.reject({
+        response: {
+          status: 400,
+          data: {
+            errors: {
+              error: ["Something does not work"]
+            }
+          }
+        }
+      })
+    );
+    const history = {
+      push: jest.fn()
+    };
+    axios.post.mockImplementation(() =>
+      Promise.resolve({
+        slug: "article-1"
+      })
+    );
+    const wrapper = setup({ ShowMessage, postArticle, history });
+    wrapper
+      .instance()
+      .createArticle({
+        preventDefault: jest.fn()
+      })
+      .then(() => {
+        expect(ShowMessage).toHaveBeenCalledWith({
+          message: "Something does not work",
+          type: "error"
+        });
+      });
+  });
+});

--- a/src/containers/articles/__tests__/viewArticle.spec.js
+++ b/src/containers/articles/__tests__/viewArticle.spec.js
@@ -1,0 +1,97 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { MemoryRouter, Route } from "react-router-dom";
+
+import axios from "axios";
+import { findByTestAttr } from "../../../testutils";
+import renderer from "../../../testutils/renderer";
+import { ViewArticle } from "../ViewArticle";
+
+jest.spyOn(axios, "get");
+
+const article = {
+  id: 4,
+  image_url: "image_url",
+  slug: "dragon-rider",
+  avg_rating: 0,
+  author: {
+    username: "Kimaiyo",
+    image: ""
+  },
+  body: "Lets and fly",
+  title: "rider",
+  description: "Ever wogon flies?",
+  tags: [],
+  read_time: "1 min read"
+};
+
+const viewArticle = jest.fn();
+
+const setup = (props = { article }) => {
+  return shallow(<ViewArticle {...props} />);
+};
+
+describe("", () => {
+  test("should render page without errors", () => {
+    const wrapper = setup();
+    renderer(wrapper, "view-test");
+  });
+  test("should render page without errors without article ", () => {
+    const set = (props = {}) => {
+      return shallow(<ViewArticle {...props} />);
+    };
+    const wrapper = set();
+    renderer(wrapper, "no-view-test");
+  });
+  test("Should call componentsdidmount when component is rendered", () => {
+    const wrapper = shallow(
+      <MemoryRouter initialEntries={["/articles/article"]}>
+        <Route
+          path="/articles/:slug"
+          render={props => (
+            <ViewArticle {...props} {...{ viewArticle, article }} />
+          )}
+        />
+      </MemoryRouter>
+    )
+      .dive()
+      .dive()
+      .dive()
+      .dive()
+      .dive()
+      .dive();
+    wrapper.instance().componentDidMount();
+    expect(viewArticle).toHaveBeenCalledWith("article");
+  });
+
+  test("Only author should view the delete button", () => {
+    localStorage.setItem("username", "Kimaiyo");
+    localStorage.setItem("token", "token");
+    const history = {
+      push: jest.fn()
+    };
+    const deleteArticle = jest.fn(() => Promise.resolve({ status: 204 }));
+    const wrapper = setup({ article, deleteArticle, history });
+    const button = findByTestAttr(wrapper, "delete-button");
+
+    button.simulate("click");
+    expect(deleteArticle).toBeCalledWith("dragon-rider", "token");
+  });
+  test("should should redirect to homepage", () => {
+    jest.spyOn(axios, "delete");
+    localStorage.setItem("username", "Kimaiyo");
+    localStorage.setItem("token", "token");
+    const history = {
+      push: jest.fn()
+    };
+    axios.delete.mockImplementation(() => Promise.resolve({ status: 204 }));
+    const deleteArticle = jest.fn(() => Promise.resolve({ status: 204 }));
+    const wrapper = setup({ article, deleteArticle, history });
+    wrapper
+      .instance()
+      .handleDelete("data")()
+      .then(() => {
+        expect(history.push).toBeCalledWith("/");
+      });
+  });
+});

--- a/src/index.html
+++ b/src/index.html
@@ -20,6 +20,9 @@
     <div id="app"></div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
     <script>
+      var chip = {
+        tag: "chip content"
+      };
       document.addEventListener("DOMContentLoaded", function() {
         var elems = document.querySelectorAll(".sidenav");
         var instances = M.Sidenav.init(elems);
@@ -33,6 +36,8 @@
           coverTrigger: false
         };
         var dropdownInstances = M.Dropdown.init(dropdownElems, options);
+        var elems = document.querySelectorAll(".chips");
+        var instances = M.Chips.init(elems);
       });
     </script>
   </body>

--- a/src/redux/actions/__tests__/articleActions.spec.js
+++ b/src/redux/actions/__tests__/articleActions.spec.js
@@ -1,0 +1,148 @@
+import axios from "axios";
+import {
+  getArticles,
+  postArticle,
+  viewArticle,
+  updateArticle,
+  deleteArticle
+} from "../articleActions";
+
+import { storeFactory } from "../../../testutils";
+
+const data = {
+  article: {
+    id: 1,
+    title: "dragon rider",
+    description: "Ever wonder how a dragon flies?",
+    body: "Lets all breathe fire and fly",
+    image_url: "image_url",
+    author: {
+      username: "Kimaiyo",
+      bio: "",
+      image: "image.url"
+    },
+    created_at: "2019-04-23T08:13:31.592916Z",
+    updated_at: "2019-04-23T08:13:31.592948Z",
+    slug: "dragon-rider",
+    avg_rating: 0,
+    rating_count: 0,
+    tags: [],
+    favorited: true,
+    favoritesCount: 1,
+    read_time: "1 min read",
+    flag: ""
+  }
+};
+
+const store = storeFactory();
+const token = "token";
+
+const resdata = {
+  article: {
+    title: "Atlas V",
+    description: "largest and most powerful rocket",
+    body: "I think it took people to space",
+    image_url: "image_url",
+    tags: []
+  }
+};
+
+const testfunc = (method, func) => {
+  jest.spyOn(axios, method);
+  if (method === "post") {
+    axios.post.mockImplementation(() => Promise.resolve({ data }));
+  } else if (method === "get") {
+    axios.get.mockImplementation(() => Promise.resolve({ data }));
+  } else {
+    axios.put.mockImplementation(() => Promise.resolve({ data }));
+  }
+  return store.dispatch(func(resdata, token)).then(() => {
+    const newState = store.getState();
+    expect(newState.articles).toEqual({
+      articles: [],
+      article: data.article
+    });
+  });
+};
+
+describe("Test for all Article Actions", () => {
+  test("should fetch a single article", () => {
+    testfunc("get", viewArticle);
+  });
+
+  test("should post an article ", () => {
+    testfunc("post", postArticle);
+  });
+  test("should update an article", () => {
+    testfunc("put", updateArticle);
+  });
+
+  test("should delete an article", () => {
+    jest.spyOn(axios, "delete");
+    const slug = "slug";
+
+    axios.delete.mockImplementation(() =>
+      Promise.resolve({
+        status: 204
+      })
+    );
+
+    store.dispatch(deleteArticle(slug, token)).then(data => {
+      expect(data).toEqual({ status: 204 });
+    });
+  });
+
+  test("should show error message snackbar", () => {
+    jest.spyOn(axios, "get");
+
+    axios.get.mockImplementation(() => Promise.reject({}));
+
+    store.dispatch(getArticles()).then(() => {
+      const newState = store.getState();
+      expect(newState.toasts.length).toBe(1);
+    });
+  });
+
+  test("should fetch all the articles in the database", () => {
+    jest.spyOn(axios, "get");
+    const data = {
+      articles: [
+        {
+          author: {
+            username: "Kimaiyo",
+            bio: "",
+            image: ""
+          },
+          created_at: "2019-04-23T08:13:31.592916Z",
+          updated_at: "2019-04-23T08:13:31.592948Z",
+          slug: "dragon-rider",
+          title: "falcon 9",
+          description: "Best rocket booster ever",
+          body: "Two of them make up the falcon heavy",
+          image_url: "image_url",
+          avg_rating: 0,
+          rating_count: 0,
+          tags: [],
+          read_time: "1 min read"
+        }
+      ]
+    };
+
+    const store = storeFactory();
+
+    axios.get.mockImplementation(() =>
+      Promise.resolve({
+        data
+      })
+    );
+
+    return store.dispatch(getArticles()).then(() => {
+      const newState = store.getState();
+
+      expect(newState.articles).toEqual({
+        article: null,
+        articles: data.articles
+      });
+    });
+  });
+});

--- a/src/redux/actions/articleActions.js
+++ b/src/redux/actions/articleActions.js
@@ -1,0 +1,72 @@
+import articleActions from "./types";
+import { apiCalls, deleteCalls } from "../../Helpers/axios";
+import { ShowMessage } from "../../redux/actions/SnackBarAction";
+
+export const getArticles = () => dispatch => {
+  const url = "/articles";
+  return apiCalls("get", url)
+    .then(data => {
+      dispatch({
+        type: articleActions.GET_ARTICLES,
+        payload: data.data.articles
+      });
+    })
+    .catch(() => {
+      dispatch(
+        ShowMessage({
+          message: "Oops! server error please reload the page",
+          type: "error"
+        })
+      );
+    });
+};
+
+export const viewArticle = slug => dispatch => {
+  const url = "/articles/" + slug;
+  dispatch({
+    type: articleActions.SINGLE_ARTICLE,
+    payload: null
+  });
+  return apiCalls("get", url).then(data => {
+    dispatch({
+      type: articleActions.SINGLE_ARTICLE,
+      payload: data.data.article
+    });
+  });
+};
+
+export const postArticle = (data, token) => dispatch => {
+  const url = "/articles";
+
+  return apiCalls("post", url, data, {
+    Authorization: `Bearer ` + token
+  }).then(data => {
+    dispatch({
+      type: articleActions.SINGLE_ARTICLE,
+      payload: data.data.article
+    });
+    return data.data.article;
+  });
+};
+
+export const updateArticle = (slug, data, token) => dispatch => {
+  const url = "/articles/" + slug;
+
+  return apiCalls("put", url, data, {
+    Authorization: `Bearer ` + token
+  }).then(data => {
+    dispatch({
+      type: articleActions.SINGLE_ARTICLE,
+      payload: data.data.article
+    });
+    return data.data.article;
+  });
+};
+
+export const deleteArticle = (slug, token) => dispatch => {
+  const url = "/articles/" + slug;
+
+  return deleteCalls("delete", url, token).then(data => {
+    return data;
+  });
+};

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -16,10 +16,14 @@ const notificationTypes = {
   GET_NOTIFICATIONS: "GET_NOTIFICATIONS"
 };
 
-const types = {
-  ...profiletypes,
-  ...Snackbar,
-  ...notificationTypes
+const articleActions = {
+  GET_ARTICLES: "GET_ARTICLES",
+  SINGLE_ARTICLE: "SINGLE_ARTICLE"
 };
 
-export default types;
+export default {
+  ...Snackbar,
+  ...articleActions,
+  ...profiletypes,
+  ...notificationTypes
+};

--- a/src/redux/reducers/ArticlesReducer.js
+++ b/src/redux/reducers/ArticlesReducer.js
@@ -1,0 +1,17 @@
+import articleActions from "../actions/types";
+
+const initialState = {
+  articles: [],
+  article: null
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case articleActions.GET_ARTICLES:
+      return { ...state, articles: action.payload };
+    case articleActions.SINGLE_ARTICLE:
+      return { ...state, article: action.payload };
+    default:
+      return state;
+  }
+};

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -1,4 +1,6 @@
 import { combineReducers } from "redux";
+
+import articles from "./ArticlesReducer";
 import MessageReducer from "./SnackBarReducer";
 import userProfile from "./userProfile/userProfile";
 import notifications from "./notifications";
@@ -6,5 +8,6 @@ import notifications from "./notifications";
 export default combineReducers({
   profile: userProfile,
   toasts: MessageReducer,
-  notifications: notifications
+  notifications: notifications,
+  articles
 });

--- a/src/routes.js
+++ b/src/routes.js
@@ -2,6 +2,10 @@ import Notfound from "./components/Errors/NotFound";
 import Login from "./containers/Login/Login";
 import Profile from "./containers/Profile/Profile";
 import Signup from "./containers/Signup/Signup";
+import Articles from "./containers/articles/Articles";
+import ViewArticle from "./containers/articles/ViewArticle";
+import PostArticle from "./containers/articles/PostArticle";
+import EditArticle from "./containers/articles/EditArticle";
 
 const routes = [
   {
@@ -39,6 +43,38 @@ const routes = [
     private: false,
     name: "Signup page",
     component: Signup
+  },
+  {
+    path: "/",
+    key: "Home",
+    exact: true,
+    private: false,
+    name: "Articles",
+    component: Articles
+  },
+  {
+    path: "/articles/:slug",
+    key: "Article",
+    exact: true,
+    private: false,
+    name: "Article",
+    component: ViewArticle
+  },
+  {
+    path: "/articles",
+    key: "Post Article",
+    exact: true,
+    private: false,
+    name: "PostArticle",
+    component: PostArticle
+  },
+  {
+    path: "/edit/:slug",
+    key: "Edit Article",
+    exact: true,
+    private: false,
+    name: "EditArticle",
+    component: EditArticle
   },
   {
     path: "",

--- a/src/testutils/renderer.js
+++ b/src/testutils/renderer.js
@@ -1,0 +1,8 @@
+import { findByTestAttr } from "./index";
+
+const renderer = (wrapper, tag) => {
+  const tested = findByTestAttr(wrapper, tag);
+  expect(tested.length).toBe(1);
+};
+
+export default renderer;

--- a/src/testutils/simulator.js
+++ b/src/testutils/simulator.js
@@ -1,0 +1,14 @@
+import { findByTestAttr } from "./index";
+
+const simulator = (wrapper, tag) => {
+  const editable = findByTestAttr(wrapper, tag);
+  editable.simulate("change", {
+    target: {
+      value: "Kimaiyo's Article"
+    }
+  });
+
+  expect(findByTestAttr(wrapper, tag).prop("value")).toBe("Kimaiyo's Article");
+};
+
+export default simulator;

--- a/src/utils/links.js
+++ b/src/utils/links.js
@@ -1,6 +1,9 @@
 const NavLinks = {
   alwaySeen: [{ name: "Home", link: "/" }],
-  auth: [{ name: "Profile", link: "/profile" }],
+  auth: [
+    { name: "Profile", link: "/profile" },
+    { name: "New Article", link: "/articles" }
+  ],
   anonymous: [
     { name: "Login", link: "/login" },
     { name: "Sign up", link: "/signup" }


### PR DESCRIPTION
#### Title
This PR allows a user to view all articles, view a single article,post a new article, update an existing article that they have written and delete an article.

#### Description
A non-registered user should be able to view a single article and all articles on the platform. Registered users should be able to post a new article and also update and delete an article that they have authored.


#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue) 

- [x] New feature (non-breaking change which adds functionality) 


- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) 


- [ ] This change requires a documentation update


#### How Has This Been Tested?
- [x] unit tests

#### Checklist:

- [x] Add reducers for articles
- [x] Add actions to get data from API
- [x] Add helper function
- [x] Add UI for vewing a single and multiple articles
- [x] Add UI for editing and creating articles
- [x] Finish all CRUD functionality
- [x] Add tests
 
#### PT stories
[#166980308](https://www.pivotaltracker.com/story/show/166980308)