### PR TITLE
166980310-create & view comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "webpack --config webpack/webpack.config.prod.js",
-    "start": "serve -s dist",
+    "start": "cross-env NODE_ENV=production serve -s dist",
     "dev": "webpack-dev-server --open --config webpack/webpack.config.dev.js",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/src/Helpers/__tests__/date.spec.js
+++ b/src/Helpers/__tests__/date.spec.js
@@ -1,0 +1,8 @@
+import { dateFormatter } from "../date";
+
+describe("dateFormatter", () => {
+  test("should render correct date in correct format", () => {
+    const newFormattedDate = dateFormatter("2019-07-15T17:22:50.754199Z");
+    expect(newFormattedDate.includes("JUL")).toBe(true);
+  });
+});

--- a/src/Helpers/date.js
+++ b/src/Helpers/date.js
@@ -1,0 +1,37 @@
+/**
+ * an array of months
+ */
+const months = [
+  "JAN",
+  "FEB",
+  "MAR",
+  "APR",
+  "MAY",
+  "JUN",
+  "JUL",
+  "AUG",
+  "SEP",
+  "OCT",
+  "NOV",
+  "DEC"
+];
+/**
+ * this function formats a date to a much pleasant format
+ * @param {Date} date - date to be parsed
+ */
+export const dateFormatter = date => {
+  let current_datetime = new Date(date);
+  return (
+    current_datetime.getFullYear() +
+    "-" +
+    months[current_datetime.getMonth()] +
+    "-" +
+    current_datetime.getDate() +
+    " " +
+    current_datetime.getHours() +
+    ":" +
+    current_datetime.getMinutes() +
+    ":" +
+    current_datetime.getSeconds()
+  );
+};

--- a/src/components/Comments/CommentsAvatar.js
+++ b/src/components/Comments/CommentsAvatar.js
@@ -1,0 +1,24 @@
+import React from "react";
+
+import { dateFormatter } from "../../Helpers/date";
+import userImage from "../../assets/images/user.png";
+
+import "./Styles/commentsAvatar.css";
+export default ({ user: { image, username }, created_at }) => (
+  <div
+    className="comment-avatar-container"
+    data-test="comments-avatar-container"
+  >
+    <div className="avatar-image">
+      <img
+        src={image ? image : userImage}
+        alt={username}
+        data-test="comment-avatar"
+      />
+    </div>
+    <div className="comment-header-details">
+      <div>{username}</div>
+      <div>{dateFormatter(created_at)}</div>
+    </div>
+  </div>
+);

--- a/src/components/Comments/CommentsCards.js
+++ b/src/components/Comments/CommentsCards.js
@@ -1,0 +1,19 @@
+import React from "react";
+
+import CommentsAvatar from "./CommentsAvatar";
+
+import "./Styles/commentsCards.css";
+
+export default ({ comments }) =>
+  comments.length > 0 ? (
+    comments.map((comment, i) => (
+      <div key={i} className="card card-padding">
+        <CommentsAvatar {...comment} />
+        <p>{comment.body}</p>
+      </div>
+    ))
+  ) : (
+    <div className="card card-padding" data-test="no-comments-present">
+      <h6>No comment has been created, create the first one</h6>
+    </div>
+  );

--- a/src/components/Comments/CommentsLoading.js
+++ b/src/components/Comments/CommentsLoading.js
@@ -1,0 +1,14 @@
+import React from "react";
+import "./Styles/LoadingCard.css";
+import "../../assets/css/loading.css";
+
+export default props =>
+  [1, 2, 3, 4, 5].map(n => (
+    <div
+      data-test="loading-comments"
+      key={n}
+      className="card animated-background loading-card"
+    >
+      <br />
+    </div>
+  ));

--- a/src/components/Comments/Styles/LoadingCard.css
+++ b/src/components/Comments/Styles/LoadingCard.css
@@ -1,0 +1,5 @@
+.loading-card {
+  height: 150px;
+  margin-bottom: 10px;
+  position: relative;
+}

--- a/src/components/Comments/Styles/commentsAvatar.css
+++ b/src/components/Comments/Styles/commentsAvatar.css
@@ -1,0 +1,14 @@
+.comment-avatar-container {
+  display: flex;
+}
+.avatar-image > img {
+  width: 45px;
+  height: 45px;
+  border-radius: 50%;
+  margin-right: 5px;
+}
+
+.comment-header-details {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/components/Comments/Styles/commentsCards.css
+++ b/src/components/Comments/Styles/commentsCards.css
@@ -1,0 +1,3 @@
+.card-padding {
+  padding: 10px;
+}

--- a/src/components/Comments/__tests__/commentsAvatar.spec.js
+++ b/src/components/Comments/__tests__/commentsAvatar.spec.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import { findByTestAttr } from "../../../testutils";
+
+import CommentsAvatar from "../CommentsAvatar";
+
+const user = {
+  image: "",
+  username: "tev"
+};
+
+const setUp = (
+  props = {
+    user
+  }
+) => shallow(<CommentsAvatar {...props} />);
+
+describe("<CommentsAvatar />", () => {
+  test("should render without error", () => {
+    const wrapper = setUp();
+    expect(wrapper.exists()).toBe(true);
+  });
+  test("should render user image if its provided", () => {
+    const image = "https://myimage.jpg";
+    const wrapper = setUp({ user: { ...user, image } });
+    const imgAvatar = findByTestAttr(wrapper, "comment-avatar");
+    expect(imgAvatar.props().src).toBe(image);
+  });
+});

--- a/src/components/Comments/__tests__/commentsCards.spec.js
+++ b/src/components/Comments/__tests__/commentsCards.spec.js
@@ -1,0 +1,32 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import { findByTestAttr } from "../../../testutils";
+import Avatar from "../CommentsAvatar";
+import CommentsCards from "../CommentsCards";
+
+const comments = [
+  {
+    user: {},
+    created_at: new Date()
+  }
+];
+
+const setUp = (
+  props = {
+    comments
+  }
+) => shallow(<CommentsCards {...props} />);
+
+describe("<CommentsCards />", () => {
+  test("should render CommentsCards without error", () => {
+    const wrapper = setUp();
+    expect(wrapper.find(Avatar).length).toBe(1);
+  });
+
+  test("should render no-comments-present card of comments are not present", () => {
+    const wrapper = setUp({ comments: [] });
+    const noCommentCard = findByTestAttr(wrapper, "no-comments-present");
+    expect(noCommentCard.length).toBe(1);
+  });
+});

--- a/src/components/Comments/__tests__/commentsLoading.spec.js
+++ b/src/components/Comments/__tests__/commentsLoading.spec.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { findByTestAttr } from "../../../testutils";
+
+import Loadingcomments from "../CommentsLoading";
+
+describe("<Loadingcomments />", () => {
+  test("should render loading comments container", () => {
+    const wrapper = shallow(<Loadingcomments />);
+    const loadingItems = findByTestAttr(wrapper, "loading-comments");
+    expect(loadingItems.length).toBe(5);
+  });
+});

--- a/src/components/Profile/Infoitem.js
+++ b/src/components/Profile/Infoitem.js
@@ -1,10 +1,12 @@
 import React from "react";
 
+import "./Styles/infoitem.css";
+
 export default ({ propname, value, icon }) => (
-  <li data-test="info-item" className="collection-item avatar">
+  <li data-test="info-item" className="collection-item info-item avatar">
     <i className="material-icons circle">{icon}</i>
     <span className="title">{propname}</span>
     <br />
-    {value}
+    <p>{value}</p>
   </li>
 );

--- a/src/components/Profile/Styles/infoitem.css
+++ b/src/components/Profile/Styles/infoitem.css
@@ -1,0 +1,5 @@
+.info-item {
+  width: 100% !important;
+  height: auto !important;
+  border-bottom: none !important;
+}

--- a/src/components/TextArea/Textarea.js
+++ b/src/components/TextArea/Textarea.js
@@ -1,0 +1,12 @@
+import React from "react";
+
+export default ({ label, id, ...other }) => {
+  return (
+    <div className="row">
+      <div className="input-field col s12">
+        <textarea {...other} id={id} className={"materialize-textarea"} />
+        <label htmlFor={id}>{label}</label>
+      </div>
+    </div>
+  );
+};

--- a/src/components/TextArea/__tests__/textarea.spec.js
+++ b/src/components/TextArea/__tests__/textarea.spec.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import renderer from "../../../testutils/renderer";
+
+import Textarea from "../Textarea";
+
+describe("<Textarea />", () => {
+  test("should render text area without errors", () => {
+    const wrapper = shallow(<Textarea id="textarea" data-test="textarea" />);
+    renderer(wrapper, "textarea");
+  });
+});

--- a/src/components/TextArea/index.js
+++ b/src/components/TextArea/index.js
@@ -1,0 +1,5 @@
+/**
+ * re-export the components so that we can import them from this file
+ */
+
+export { default as Textarea } from "./Textarea";

--- a/src/containers/Comments/Comments.js
+++ b/src/containers/Comments/Comments.js
@@ -1,0 +1,209 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { connect } from "react-redux";
+
+import { Textarea } from "../../components/TextArea/";
+import CommentsContainerList from "../../components/Comments/CommentsCards";
+import LoadingCommentsCard from "../../components/Comments/CommentsLoading";
+import {
+  createComment,
+  getArticleComments
+} from "../../redux/actions/commentsActions/commentsActions";
+import { ShowMessage } from "../../redux/actions/SnackBarAction";
+
+import "./Styles/Comments.css";
+export class UnconnectedCommentsContainer extends React.Component {
+  state = {
+    showComments: false,
+    commentBody: "",
+    submitting: false
+  };
+
+  /**
+   * handles the commentsBody on change functionality
+   */
+  handleCommentBody = event => {
+    event.persist();
+    this.setState({
+      commentBody: event.target.value
+    });
+  };
+
+  /**
+   * toggles the showArticleComments from false to true
+   * & triggers the call to getting the article's comments
+   */
+  showArticleComments = () => {
+    const {
+      getArticleComments,
+      article: { slug }
+    } = this.props;
+    this.setState(({ showComments }) => ({
+      showComments: true
+    }));
+    getArticleComments(slug);
+  };
+
+  /**
+   * this function handles the posting of comments
+   */
+  postComment = event => {
+    event.preventDefault();
+    const { commentBody } = this.state;
+    this.setState({
+      submitting: true
+    });
+    const {
+      createComment,
+      article: { slug }
+    } = this.props;
+    return createComment(slug, {
+      body: commentBody
+    })
+      .then(this.handleSuccessfullCommentCreation)
+      .catch(this.handleCommentCreationFailure);
+  };
+
+  /**
+   * this method is called when a comment is created successfully on the API
+   */
+  handleSuccessfullCommentCreation = event => {
+    const { ShowMessage } = this.props;
+    this.setState({
+      commentBody: "",
+      submitting: false
+    });
+
+    ShowMessage("Created the comment successfully.");
+  };
+
+  /**
+   * this method is called when a comment is not created successfully
+   */
+  handleCommentCreationFailure = err => {
+    const { ShowMessage } = this.props;
+    this.setState({
+      submitting: false
+    });
+    ShowMessage({
+      message:
+        "Something went wrong creating the comment, please try again and make sure the comment field is not blank",
+      type: "error"
+    });
+  };
+
+  /**
+   * renders the show comments button IFF a user is logged in
+   * &  this.state.showComments is false
+   */
+  renderShowCommentsButton = () => {
+    const { showComments } = this.state;
+    return localStorage.getItem("token") && !showComments ? (
+      <a
+        className="waves-effect waves-light orange darken-1 btn-small full-width"
+        data-test="show-comments"
+        onClick={this.showArticleComments}
+      >
+        Show Comments
+      </a>
+    ) : null;
+  };
+
+  /**
+   * you must be logged in to view the article's comments
+   */
+  renderLoginToViewComments = () => {
+    return (
+      !localStorage.getItem("token") && (
+        <Link
+          data-test="login-to-view-comments"
+          className="waves-effect waves-light orange darken-1 btn full-width"
+          to="/login"
+        >
+          Login to view the article's comments
+        </Link>
+      )
+    );
+  };
+
+  /**
+   * renders the new comments form IFF
+   * a user is logged in &&
+   * this.state.showComments is true
+   */
+
+  renderCommentsForm = () => {
+    const { showComments, commentBody, submitting } = this.state;
+    return localStorage.getItem("token") && showComments ? (
+      <div>
+        <h4>Comments</h4>
+        <form
+          onSubmit={this.postComment}
+          data-test="new-comments-form"
+          className="card comment-form"
+        >
+          <Textarea
+            id="new-comment"
+            label="Comment"
+            onChange={this.handleCommentBody}
+            value={commentBody}
+          />
+          <button
+            type="submit"
+            disabled={!/\S/.test(commentBody)}
+            className="waves-effect waves-light orange darken-1 btn-small submit-comment"
+            data-test="send-comment"
+            onClick={this.postComment}
+          >
+            {submitting ? "Sending ..." : "Comment"}
+          </button>
+        </form>
+      </div>
+    ) : null;
+  };
+
+  /**
+   * this method is responsible for rendering the fetchedComments
+   */
+
+  renderArticleCommentsCards = () => {
+    const { showComments } = this.state;
+    const {
+      comments: { comments }
+    } = this.props;
+    return showComments && <CommentsContainerList {...{ comments }} />;
+  };
+
+  renderLoadingCards = () => {
+    const {
+      comments: { isLoading }
+    } = this.props;
+
+    return isLoading && <LoadingCommentsCard />;
+  };
+
+  render() {
+    return (
+      <div data-test="comments-container-div">
+        {this.renderLoginToViewComments()}
+        {this.renderShowCommentsButton()}
+        {this.renderCommentsForm()}
+        {this.renderLoadingCards()}
+        {this.renderArticleCommentsCards()}
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  comments: state.comments
+});
+
+export default connect(
+  mapStateToProps,
+  {
+    createComment,
+    ShowMessage,
+    getArticleComments
+  }
+)(UnconnectedCommentsContainer);

--- a/src/containers/Comments/Styles/Comments.css
+++ b/src/containers/Comments/Styles/Comments.css
@@ -1,0 +1,12 @@
+.full-width {
+  width: 100%;
+  margin-bottom: 30px;
+}
+
+.submit-comment {
+  left: 85%;
+}
+
+.comment-form {
+  padding: 20px;
+}

--- a/src/containers/Comments/__tests__/comments.spec.js
+++ b/src/containers/Comments/__tests__/comments.spec.js
@@ -1,0 +1,147 @@
+import React from "react";
+import { shallow } from "enzyme";
+import CommentsContainer, { UnconnectedCommentsContainer } from "../Comments";
+
+import { findByTestAttr, storeFactory } from "../../../testutils";
+import CommentsLoading from "../../../components/Comments/CommentsLoading";
+
+const commentsObj = {
+  isLoading: false
+};
+/**
+ *
+ * @param {object} props - props passed to the comments component
+ */
+const setUp = (
+  props = {
+    comments: commentsObj
+  }
+) => shallow(<UnconnectedCommentsContainer {...props} />);
+
+const article = {
+  slug: "new-article"
+};
+
+/**
+ * set localStorage in a test
+ */
+const setLocalStorage = () => localStorage.setItem("token", "yes");
+
+/**
+ *
+ * @param {String} nodestring - data-test string
+ */
+const testForComponentLength = nodestring => {
+  const wrapper = setUp();
+
+  const targetDiv = findByTestAttr(wrapper, nodestring);
+  expect(targetDiv.length).toBe(1);
+};
+
+describe("<UnconnectedCommentsContainer />", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+  test("should render without error", () => {
+    testForComponentLength("comments-container-div");
+  });
+
+  test("should render ConnectedComponent without error", () => {
+    const store = storeFactory({
+      comments: {}
+    });
+    const connectedWrapper = shallow(<CommentsContainer {...{ store }} />);
+    expect(connectedWrapper.exists()).toBe(true);
+  });
+
+  test("should update commentsBody state on calling handleCommentBody", () => {
+    const wrapper = setUp();
+    wrapper.instance().handleCommentBody({
+      persist: jest.fn(),
+      target: {
+        value: "New comment body"
+      }
+    });
+
+    expect(wrapper.state().commentBody).toBe("New comment body");
+  });
+
+  test("should fetch comments with article slug when showArticleComments is called", () => {
+    const getArticleComments = jest.fn();
+    const wrapper = setUp({
+      comments: { ...commentsObj },
+      article,
+      getArticleComments
+    });
+    wrapper.instance().showArticleComments();
+    expect(getArticleComments).toHaveBeenCalledWith(article.slug);
+  });
+
+  test("should call showMessage upon successfully creating a comment", done => {
+    const createComment = jest.fn(() => Promise.resolve({}));
+    const ShowMessage = message => {
+      expect(message).toBe("Created the comment successfully.");
+      done();
+    };
+    const wrapper = setUp({
+      comments: commentsObj,
+      article,
+      createComment,
+      ShowMessage
+    });
+    wrapper.setState({ commentBody: "This article is great" });
+    wrapper.instance().postComment({
+      preventDefault: jest.fn()
+    });
+  });
+
+  test("should call showMessage with error message upon comment creation failure", done => {
+    const ShowMessage = message => {
+      expect(message).toEqual({
+        message:
+          "Something went wrong creating the comment, please try again and make sure the comment field is not blank",
+        type: "error"
+      });
+      done();
+    };
+    const wrapper = setUp({
+      comments: commentsObj,
+      article,
+      createComment: jest.fn(() => Promise.reject({})),
+      ShowMessage
+    });
+    wrapper.instance().postComment({
+      preventDefault: jest.fn()
+    });
+  });
+
+  test("should render the showCOmments button if showComments is false", () => {
+    setLocalStorage();
+    testForComponentLength("show-comments");
+  });
+
+  test("should render login btn if user is not logged in", () => {
+    testForComponentLength("login-to-view-comments");
+  });
+
+  test("should render commentsForm component if showComments is true & user is loggedin", () => {
+    setLocalStorage();
+    const wrapper = setUp();
+    const submitBtn = () => findByTestAttr(wrapper, "send-comment");
+    wrapper.setState({ showComments: true, submitting: true });
+    expect(findByTestAttr(wrapper, "new-comments-form").length).toBe(1);
+    expect(submitBtn().text()).toBe("Sending ...");
+    wrapper.setState({ submitting: false });
+    expect(submitBtn().text()).toBe("Comment");
+  });
+
+  test("should render LoadingCommentsCard ", () => {
+    const wrapper = setUp({
+      comments: {
+        isLoading: true
+      }
+    });
+
+    expect(wrapper.find(CommentsLoading).length).toBe(1);
+  });
+});

--- a/src/containers/Comments/index.js
+++ b/src/containers/Comments/index.js
@@ -1,0 +1,4 @@
+/**
+ * re-export the components so that we can import them from this file
+ */
+export { default as CommentsContainer } from "./Comments";

--- a/src/containers/articles/Articles.js
+++ b/src/containers/articles/Articles.js
@@ -31,7 +31,7 @@ export class Articles extends Component {
           <div className="col s9 pull-s3">
             {loadingArticles && <Loader />}
             {this.props.articles.map(article => (
-              <div>
+              <div key={article.id}>
                 <ArticleCard article={article} />
               </div>
             ))}

--- a/src/containers/articles/ViewArticle.js
+++ b/src/containers/articles/ViewArticle.js
@@ -3,6 +3,7 @@ import { connect } from "react-redux";
 import { Link } from "react-router-dom";
 import { viewArticle, deleteArticle } from "../../redux/actions/articleActions";
 import ArticleEditor from "../../components/Article/ArticleEditor";
+import { CommentsContainer } from "../Comments";
 import Loader from "../../components/Article/Loader";
 
 import "../../components/Article/styles/articles.css";
@@ -90,6 +91,10 @@ export class ViewArticle extends Component {
                   </div>
                 </div>
               </div>
+            </div>
+            {/* comments container */}
+            <div className={"container"}>
+              <CommentsContainer {...{ article }} />
             </div>
           </div>
         ) : (

--- a/src/redux/actions/commentsActions/__tests__/commentActions.spec.js
+++ b/src/redux/actions/commentsActions/__tests__/commentActions.spec.js
@@ -1,0 +1,65 @@
+import axios from "axios";
+
+import { createComment, getArticleComments } from "../commentsActions";
+import { storeFactory } from "../../../../testutils";
+
+jest.spyOn(axios, "get");
+jest.spyOn(axios, "post");
+
+const comment = {
+  id: 1,
+  body: "new comment"
+};
+
+/**
+ *
+ * @param {Promise} promisefn - a function that returns a promise
+ * @returns Jest expect
+ */
+const commentsActionTestCaseFunction = (
+  promisefn,
+  expectedValue = [comment]
+) => {
+  const store = storeFactory();
+  store.dispatch(promisefn).then(() => {
+    const newState = store.getState();
+    expect(newState.comments).toEqual({
+      comments: expectedValue,
+      isLoading: false
+    });
+  });
+};
+
+describe("createComment fns", () => {
+  test("should create a comment and update the redux store", () => {
+    axios.post.mockImplementation(() => {
+      return Promise.resolve({
+        data: comment
+      });
+    });
+
+    commentsActionTestCaseFunction(createComment("article-1", comment));
+  });
+});
+
+describe("getArticleComments fns", () => {
+  test("should set the comments fetched from the api to the comments List.", () => {
+    axios.get.mockImplementation(() =>
+      Promise.resolve({
+        data: {
+          Comments: [comment]
+        }
+      })
+    );
+    commentsActionTestCaseFunction(getArticleComments("article-1"));
+  });
+
+  test("should return empty array if the article has no comments", () => {
+    axios.get.mockImplementation(() =>
+      Promise.resolve({
+        data: {}
+      })
+    );
+    commentsActionTestCaseFunction(getArticleComments("article-1"), []);
+  });
+});

--- a/src/redux/actions/commentsActions/commentsActions.js
+++ b/src/redux/actions/commentsActions/commentsActions.js
@@ -1,0 +1,66 @@
+import actionTypes from "../types";
+
+import { apiCalls } from "../../../Helpers/axios";
+
+const {
+  CREATE_COMMENT,
+  SET_COMMENTS,
+  SET_LOADING_COMMENTS,
+  REMOVE_LOADING_COMMENTS
+} = actionTypes;
+
+const authHeaders = {
+  Authorization: `Bearer ${localStorage.getItem("token")}`
+};
+
+/**
+ * This function creates a comment
+ * @param {String} articleSlug - the slug of the article
+ * @param {Object} comment - the comments object
+ * @returns {Promise} - returns Promise<Resolve | Reject>
+ */
+export const createComment = (articleSlug, comment) => dispatch => {
+  return apiCalls(
+    "post",
+    `/articles/${articleSlug}/comments`,
+    {
+      comment
+    },
+    { ...authHeaders }
+  ).then(({ data }) => {
+    dispatch({
+      type: CREATE_COMMENT,
+      payload: data
+    });
+  });
+};
+
+/**
+ *
+ * @param {string} articleSlug - the slug for the article which we are getting comments from
+ * @returns {Promise} - returns Promise<Resolve | Reject>
+ */
+export const getArticleComments = articleSlug => dispatch => {
+  dispatch({
+    type: SET_LOADING_COMMENTS
+  });
+
+  //set comments to an empty array before fetching
+  dispatch({
+    type: SET_COMMENTS,
+    payload: []
+  });
+  return apiCalls("get", `/articles/${articleSlug}/comments`, {
+    headers: {
+      ...authHeaders
+    }
+  }).then(({ data: { Comments = [] } }) => {
+    dispatch({
+      type: SET_COMMENTS,
+      payload: Comments
+    });
+    dispatch({
+      type: REMOVE_LOADING_COMMENTS
+    });
+  });
+};

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -23,6 +23,14 @@ const articleActions = {
   REMOVE_LOADING: "REMOVE_LOADING"
 };
 
+// comment actionTypes
+const commentActions = {
+  SET_COMMENTS: "SET_COMMENTS",
+  CREATE_COMMENT: "CREATE_COMMENT",
+  SET_LOADING_COMMENTS: "SET_LOADING_COMMENTS",
+  REMOVE_LOADING_COMMENTS: "REMOVE_LOADING_COMMENTS"
+};
+
 const tagActions = {
   TAGS: "TAGS"
 };
@@ -38,5 +46,6 @@ export default {
   ...articleActions,
   ...profiletypes,
   ...tagActions,
-  ...errorActions
+  ...errorActions,
+  ...commentActions
 };

--- a/src/redux/reducers/comments/__tests__/comments.spec.js
+++ b/src/redux/reducers/comments/__tests__/comments.spec.js
@@ -1,0 +1,75 @@
+import actionTypes from "../../../actions/types";
+import commentsReducer from "../comments";
+
+const {
+  CREATE_COMMENT,
+  SET_LOADING_COMMENTS,
+  REMOVE_LOADING_COMMENTS,
+  SET_COMMENTS
+} = actionTypes;
+
+/**
+ *
+ * @param {object} action - object that specifies the action to be applied 2the comments obj
+ * @returns {object} - new reducer object with applied action
+ */
+const reuseableCommentsReducer = action => commentsReducer(undefined, action);
+
+describe("commentsReducer Functionality", () => {
+  const comment = {
+    body: "A new comment is here"
+  };
+  test("should return default state if nothing no relevant action is passed", () => {
+    expect(
+      reuseableCommentsReducer({
+        type: "NOT_RELEVANT_TO_COMMENTS"
+      })
+    ).toEqual({
+      comments: [],
+      isLoading: false
+    });
+  });
+
+  test("should add new comment to the comments array once a new comment is created", () => {
+    expect(
+      reuseableCommentsReducer({
+        type: CREATE_COMMENT,
+        payload: comment
+      })
+    ).toEqual({
+      comments: [comment],
+      isLoading: false
+    });
+  });
+
+  test("should toggle loading prop", () => {
+    expect(
+      reuseableCommentsReducer({
+        type: SET_LOADING_COMMENTS
+      })
+    ).toEqual({
+      comments: [],
+      isLoading: true
+    });
+    expect(
+      reuseableCommentsReducer({
+        type: REMOVE_LOADING_COMMENTS
+      })
+    ).toEqual({
+      comments: [],
+      isLoading: false
+    });
+  });
+
+  test("should add new comment to the list of comments present", () => {
+    expect(
+      reuseableCommentsReducer({
+        type: SET_COMMENTS,
+        payload: [comment]
+      })
+    ).toEqual({
+      comments: [comment],
+      isLoading: false
+    });
+  });
+});

--- a/src/redux/reducers/comments/comments.js
+++ b/src/redux/reducers/comments/comments.js
@@ -1,0 +1,30 @@
+import actionTypes from "../../actions/types";
+
+const {
+  SET_COMMENTS,
+  CREATE_COMMENT,
+  SET_LOADING_COMMENTS,
+  REMOVE_LOADING_COMMENTS
+} = actionTypes;
+/**
+ * The initial State of the comments reducer
+ */
+const initialState = {
+  comments: [],
+  isLoading: false
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case SET_COMMENTS:
+      return { ...state, comments: action.payload };
+    case CREATE_COMMENT:
+      return { ...state, comments: [...state.comments, action.payload] };
+    case SET_LOADING_COMMENTS:
+      return { ...state, isLoading: true };
+    case REMOVE_LOADING_COMMENTS:
+      return { ...state, isLoading: false };
+    default:
+      return state;
+  }
+};

--- a/src/redux/reducers/comments/index.js
+++ b/src/redux/reducers/comments/index.js
@@ -1,0 +1,4 @@
+/**
+ * re-export the functions so that we can import them from this file
+ */
+export { default as CommentsReducer } from "./comments";

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -5,11 +5,13 @@ import MessageReducer from "./SnackBarReducer";
 import userProfile from "./userProfile/userProfile";
 import notifications from "./notifications";
 import tags from "./tagsReducer";
+import { CommentsReducer } from "./comments";
 
 export default combineReducers({
   toasts: MessageReducer,
   notifications: notifications,
   profile: userProfile,
   tags,
-  articles
+  articles,
+  comments: CommentsReducer
 });


### PR DESCRIPTION
#### Title
<!-- A short description of what needs to be done. -->
Users should Create and View comments

#### Description
It's important for users to be able to interact with the articles that have been created This allows them to express their thoughts on the article via writing comments and also reading  the comments that have been written by other members


#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue) 

- [x] New feature (non-breaking change which adds functionality) 


- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) 


- [ ] This change requires a documentation update


#### How Can This Been Tested?
1. Checkout to `story/166980310-create-n-view-comments` branch
2. Login to the app
3. View any article
4. Scroll to the bottom and hit `show comments`

![image](https://user-images.githubusercontent.com/12128153/61267951-93ef8800-a7a2-11e9-8bda-c42d61bdae85.png)

5. Create a new comment & view the comments that are present.

![image](https://user-images.githubusercontent.com/12128153/61267978-b386b080-a7a2-11e9-91a3-3098531e7330.png)

#### Checklist:

- [x] - create reducer for comments
- [x] - create functionality for creating a comment
- [x] - test create and view comment functions
- [x] - create functionality for viewing list of comments and loading indicator
- [x] - setup tests for the commentsContainer
- [x] - setup tests for commentsComponents

#### PT stories
[#166980310](https://www.pivotaltracker.com/story/show/166980310)