### PR TITLE
166980317 turn notifications on or off

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5263,8 +5263,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5288,15 +5287,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5313,22 +5310,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5459,8 +5453,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5474,7 +5467,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5491,7 +5483,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5500,15 +5491,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5529,7 +5518,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5618,8 +5606,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5633,7 +5620,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5729,8 +5715,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5772,7 +5757,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5794,7 +5778,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5843,15 +5826,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -10607,6 +10588,14 @@
       "requires": {
         "@babel/runtime": "^7.3.1",
         "prop-types": "^15.5.8"
+      }
+    },
+    "react-switch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-5.0.1.tgz",
+      "integrity": "sha512-Pa5kvqRfX85QUCK1Jv0rxyeElbC3aNpCP5hV0LoJpU/Y6kydf0t4kRriQ6ZYA4kxWwAYk/cH51T4/sPzV9mCgQ==",
+      "requires": {
+        "prop-types": "^15.6.2"
       }
     },
     "react-tabs": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "react-router-dom": "^5.0.1",
     "react-spring": "^8.0.27",
     "react-tabs": "^3.0.0",
+    "react-switch": "^5.0.1",
     "redux": "^4.0.1",
     "redux-devtools-extension": "^2.13.8",
     "redux-mock-store": "^1.5.3",

--- a/src/components/Profile/Profiledata.js
+++ b/src/components/Profile/Profiledata.js
@@ -3,14 +3,19 @@ import React from "react";
 import "./Styles/profiledata.css";
 import userimage from "../../assets/images/user.png";
 import InfoItem from "./Infoitem";
-
+import SwitchCheckbox from "../SwitchButton";
 /**
  *
  * renderEditComponent - function - renders a function as a child
  */
 export default ({
   data: { image, username, firstname, lastname, bio },
-  renderEditComponent
+  renderEditComponent,
+  handleAppNotifications,
+  handleEmailNotifications,
+  app_checked,
+  email_checked,
+  owner
 }) => (
   <div className="row profile-data-wrapper">
     {/* image avatar */}
@@ -35,13 +40,49 @@ export default ({
     </div>
     {/** user information */}
     <div className="col s12 m5 l8">
-      <div className="container">
-        <ul className="collection">
-          <InfoItem propname={"Firstname"} value={firstname} icon={"info"} />
-          <InfoItem propname={"Lastname"} value={lastname} icon={"info"} />
-          <InfoItem propname={"Bio"} value={bio} icon={"library_books"} />
-        </ul>
+      <div className="row">
+        <div className="col s12 m12">
+          <div className="card ">
+            <div className="card-content ">
+              <span className="card-title">Bio</span>
+              <ul className="collection">
+                <InfoItem
+                  propname={"Firstname"}
+                  value={firstname}
+                  icon={"info"}
+                />
+                <InfoItem
+                  propname={"Lastname"}
+                  value={lastname}
+                  icon={"info"}
+                />
+                <InfoItem propname={"Bio"} value={bio} icon={"library_books"} />
+              </ul>
+              {owner ? (
+                <div data-test="profile-settings">
+                  <span className="card-title">Settings</span>
+                  <ul className="collection">
+                    <SwitchCheckbox
+                      title={"In app notifications"}
+                      handleChange={handleAppNotifications}
+                      checked={app_checked}
+                    />
+
+                    <SwitchCheckbox
+                      title={"Email notifications"}
+                      handleChange={handleEmailNotifications}
+                      checked={email_checked}
+                    />
+                  </ul>
+                </div>
+              ) : (
+                ""
+              )}
+            </div>
+          </div>
+        </div>
       </div>
+      <div className="container"></div>
     </div>
     {/** edit button to be seen only by profile owner */}
     <div className="col s12 m2 l2">

--- a/src/components/Profile/__tests__/Profiledata.spec.js
+++ b/src/components/Profile/__tests__/Profiledata.spec.js
@@ -20,9 +20,16 @@ describe("<Profiledata />", () => {
   };
   test("should render without error", () => {
     const renderEditComponent = jest.fn();
-    const wrapper = setUp({ data: profile, renderEditComponent });
+    const wrapper = setUp({
+      data: profile,
+      renderEditComponent,
+      owner: true
+    });
     const container = findByTestAttr(wrapper, "profile-data-component");
     expect(container.length).toBe(1);
+
+    const profilesettings = findByTestAttr(wrapper, "profile-settings");
+    expect(profilesettings.length).toBe(1);
     expect(renderEditComponent).toBeCalled();
   });
   test("should render default image if non is provided in profile info", () => {

--- a/src/components/SwitchButton/__tests__/switchButton.spec.js
+++ b/src/components/SwitchButton/__tests__/switchButton.spec.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { shallow } from "enzyme";
+import SwitchButton from "../index";
+
+describe("Switch button", () => {
+  test("should render without errors", () => {
+    const wrapper = shallow(
+      <SwitchButton handleChange={jest.fn()} checked={true} />
+    );
+
+    expect(wrapper).toBeTruthy();
+  });
+});

--- a/src/components/SwitchButton/index.js
+++ b/src/components/SwitchButton/index.js
@@ -1,0 +1,23 @@
+import Switch from "react-switch";
+import React from "react";
+
+export default ({ handleChange, checked, title }) => (
+  <li className="collection-item info-item">
+    <span>{title}</span>
+    <label className="right">
+      <Switch
+        onChange={handleChange}
+        checked={checked}
+        onColor="#fb8c00"
+        onHandleColor="#fb8c00"
+        handleDiameter={20}
+        uncheckedIcon={false}
+        checkedIcon={false}
+        boxShadow="0px 1px 5px rgba(0, 0, 0, 0.6)"
+        activeBoxShadow="0px 0px 1px 10px rgba(0, 0, 0, 0.2)"
+        height={14}
+        width={36}
+      />
+    </label>
+  </li>
+);

--- a/src/containers/Profile/Profile.js
+++ b/src/containers/Profile/Profile.js
@@ -8,8 +8,18 @@ import { ShowMessage } from "../../redux/actions/SnackBarAction";
 import { getProfile } from "../../redux/actions/profileActions/profileActions";
 import { isLoggedIn } from "../../Helpers/authHelpers";
 import ProfileTabs from "../../components/ProfileTabs/ProfileTabs";
+import { optIn, optOut } from "../../redux/actions/notificationActions";
 
+const token = localStorage.getItem("token");
+const username = localStorage.getItem("username");
 export class UnconnectedProfile extends React.Component {
+  constructor(props) {
+    super();
+    this.state = { in_app: true, in_email: true };
+    this.handleAppNotifications = this.handleAppNotifications.bind(this);
+    this.handleEmailNotifications = this.handleEmailNotifications.bind(this);
+  }
+
   /***
    * @params - unit - takes no parameters
    * checks if the user is logged in then goes ahead
@@ -18,7 +28,13 @@ export class UnconnectedProfile extends React.Component {
   getCurrentlyLoggedInUserProfile = () => {
     const { history, getProfile, ShowMessage } = this.props;
     if (isLoggedIn()) {
-      getProfile(localStorage.getItem("username"), history);
+      return getProfile(username, history).then(profile => {
+        const { email_notifications, in_app_notifications } = profile;
+        this.setState({
+          in_app: in_app_notifications,
+          in_email: email_notifications
+        });
+      });
     } else {
       /**
        * if the user is not logged in redirect them to the login page
@@ -39,11 +55,51 @@ export class UnconnectedProfile extends React.Component {
       },
       history
     } = this.props;
+
     // fetch the data from the endpoint & pass it to redux
     return username
       ? getProfile(username, history)
       : this.getCurrentlyLoggedInUserProfile();
   }
+  handleOpts = (checked, type) => {
+    if (checked) {
+      this.props.optIn(token, type);
+    } else {
+      this.props.optOut(token, type);
+    }
+  };
+  handleAppNotifications = in_app => {
+    this.handleOpts(in_app, "in_app");
+    this.setState({ in_app: in_app });
+  };
+  handleEmailNotifications = in_email => {
+    this.handleOpts(in_email, "email");
+    this.setState({ in_email: in_email });
+  };
+  renderProfileData = (data, isOwner) => {
+    return (
+      <div>
+        {data && (
+          <div className="container" data-test="profile-data">
+            <Profiledata
+              {...{ data }}
+              renderEditComponent={profiledata =>
+                isOwner ? <Editprofile {...{ profiledata }} /> : null
+              }
+              handleAppNotifications={this.handleAppNotifications}
+              handleEmailNotifications={this.handleEmailNotifications}
+              app_checked={this.state.in_app}
+              email_checked={this.state.in_email}
+              owner={isOwner}
+            />
+            <div>
+              <ProfileTabs username={data.username} />
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  };
   render() {
     const {
       profile: { data, isLoading, isOwner }
@@ -55,20 +111,7 @@ export class UnconnectedProfile extends React.Component {
             <Loadingprofile />
           </div>
         )}
-
-        {data && (
-          <div className="container" data-test="profile-data">
-            <Profiledata
-              {...{ data }}
-              renderEditComponent={profiledata =>
-                isOwner ? <Editprofile {...{ profiledata }} /> : null
-              }
-            />
-            <div>
-              <ProfileTabs username={data.username} />
-            </div>
-          </div>
-        )}
+        {this.renderProfileData(data, isOwner)}
       </div>
     );
   }
@@ -83,7 +126,9 @@ export default withRouter(
     mapStateToProps,
     {
       getProfile,
-      ShowMessage
+      ShowMessage,
+      optIn,
+      optOut
     }
   )(UnconnectedProfile)
 );

--- a/src/containers/Profile/__tests__/Profile.test.js
+++ b/src/containers/Profile/__tests__/Profile.test.js
@@ -55,15 +55,22 @@ describe("<UnconnectedProfile />", () => {
     // setup user details to localStorage
     localStorage.setItem("token", "usertoken");
     localStorage.setItem("username", "tev");
-    const getProfile = jest.fn();
-
-    const wrapper = setUp({ profile, getProfile });
+    const getProfile = jest.fn(() => Promise.resolve({}));
+    const optOut = jest.fn(() => Promise.resolve({}));
+    const optIn = jest.fn(() => Promise.resolve({}));
+    const status = true;
+    const wrapper = setUp({ profile, getProfile, optOut, optIn });
     wrapper.instance().componentDidMount();
+    wrapper.instance().handleAppNotifications();
+    wrapper.instance().handleEmailNotifications(status);
+    wrapper.instance().renderProfileData(profile, status);
+
     expect(getProfile).toBeCalled();
   });
 
   test("should render data if loading is complete", () => {
     const profile = {
+      isOwner: true,
       isLoading: false,
       data: {
         username: "Tev",
@@ -73,6 +80,7 @@ describe("<UnconnectedProfile />", () => {
     };
     const wrapper = setUp({ profile });
     const profiledata = findByTestAttr(wrapper, "profile-data");
+
     expect(profiledata.length).toBe(1);
   });
 });

--- a/src/containers/Ratings/RatingArticle.js
+++ b/src/containers/Ratings/RatingArticle.js
@@ -42,7 +42,7 @@ export class Rating extends Component {
           total={5}
           onRate={this.handleRate.bind(this)}
         />{" "}
-        <span className="score center-align">
+        <span className="score center-align" data-test="ratings">
           {ratings ? ratings.toFixed(1) : 0}
         </span>
       </div>

--- a/src/containers/Ratings/__tests__/ratingArticle.spec.js
+++ b/src/containers/Ratings/__tests__/ratingArticle.spec.js
@@ -8,7 +8,7 @@ import { storeFactory } from "../../../testutils/index";
 
 jest.spyOn(axios, "post");
 
-const store = storeFactory();
+const store = storeFactory({ ratings: 3 });
 const data = {
   article: {
     id: 5
@@ -16,7 +16,7 @@ const data = {
   match: {
     params: { slug: "this-a-good-article" }
   },
-  ratings: 5,
+  ratings: 3,
   viewArticle: jest.fn()
 };
 

--- a/src/redux/actions/__tests__/articleActions.spec.js
+++ b/src/redux/actions/__tests__/articleActions.spec.js
@@ -168,7 +168,6 @@ const getArticlesOperation = () => {
 };
 
 describe("Filterby tags", () => {
- 
   const dispatchArticlesActions = (store, fn) => {
     getArticlesOperation();
     return store.dispatch(fn()).then(() => {

--- a/src/redux/actions/__tests__/notificationsActions.spec.js
+++ b/src/redux/actions/__tests__/notificationsActions.spec.js
@@ -1,7 +1,37 @@
 import expect from "expect";
 import WS from "jest-websocket-mock";
-import { fetchNotifications } from "../notificationActions";
+import { fetchNotifications, optIn, optOut } from "../notificationActions";
 import { storeFactory } from "../../../testutils";
+import axios from "axios";
+
+const token = "token";
+const store = storeFactory();
+
+const expectedToast = () => {
+  const newState = store.getState();
+  return expect(newState.toasts.length).toBe(1);
+};
+
+const testfunc = (method, func, type) => {
+  let action;
+  jest.spyOn(axios, method);
+
+  if (method === "post") {
+    axios.post.mockImplementation(() => Promise.resolve({}));
+    action = store.dispatch(func(token, type)).then(() => {
+      expectedToast();
+    });
+  } else if (method === "delete") {
+    axios.delete.mockImplementation(() => Promise.resolve({ status: 204 }));
+    action = store.dispatch(func(token, type)).then(data => {
+      expect(data).toEqual({ status: 204 });
+      expectedToast();
+    });
+  }
+
+  return action;
+};
+
 describe("Test websockets", () => {
   const data = {
     data: {
@@ -26,5 +56,22 @@ describe("Test websockets", () => {
     expect(state.notifications).toEqual([data.data]);
 
     server.close();
+  });
+});
+describe("Notifications settings", () => {
+  test("should opt in into app notifications", () => {
+    testfunc("post", optIn, "in_app");
+  });
+
+  test("should opt in into email notifications", () => {
+    testfunc("post", optIn, "email");
+  });
+
+  test("should opt out into in-app notifications", () => {
+    testfunc("delete", optOut, "in_app");
+  });
+
+  test("should opt out into email notifications", () => {
+    testfunc("delete", optOut, "email");
   });
 });

--- a/src/redux/actions/__tests__/ratingActions.spec.js
+++ b/src/redux/actions/__tests__/ratingActions.spec.js
@@ -14,6 +14,7 @@ const expectedResult = () => {
     ratings: resdata
   });
 };
+
 const testfunc = (method, func) => {
   let action;
   jest.spyOn(axios, method);
@@ -41,6 +42,7 @@ describe("Test article rating", () => {
   test("should show error snackbar on post rating", () => {
     snackBarError("post", setRating, 1);
   });
+
   test("should get rating", () => {
     testfunc("get", getRating);
   });

--- a/src/redux/actions/likesDislikesActions/__tests__/likesDislikesActions.spec.js
+++ b/src/redux/actions/likesDislikesActions/__tests__/likesDislikesActions.spec.js
@@ -8,6 +8,7 @@ import {
 } from "../likesDislikesActions";
 import { storeFactory } from "../../../../testutils";
 import * as snackbar from "../../SnackBarAction";
+
 jest.spyOn(snackbar, "ShowMessage");
 jest.spyOn(axios, "get");
 jest.spyOn(axios, "post");

--- a/src/redux/actions/notificationActions.js
+++ b/src/redux/actions/notificationActions.js
@@ -1,4 +1,6 @@
 import actionTypes from "./types";
+import { apiCalls, deleteCalls } from "../../Helpers/axios";
+import { ShowMessage } from "./SnackBarAction";
 
 export const fetchNotifications = url => dispatch => {
   const ws = new WebSocket(url);
@@ -10,4 +12,55 @@ export const fetchNotifications = url => dispatch => {
       payload: received_msg
     });
   };
+};
+
+const dispatchSuccessShowMessage = (dispatch, data) => {
+  dispatch(
+    ShowMessage({
+      message: data.data.data,
+      type: "success"
+    })
+  );
+};
+
+const dispatchErrorShowMessage = (dispatch, error) => {
+  dispatch(
+    ShowMessage({
+      message: error,
+      type: "error"
+    })
+  );
+};
+const message =
+  "Oops something went wrong! Kindly try again or reload the page";
+
+export const optIn = (token, type) => dispatch => {
+  const url = "/subscription/" + type + "/";
+
+  return apiCalls(
+    "post",
+    url,
+    {},
+    {
+      Authorization: `Bearer ` + token
+    }
+  )
+    .then(data => {
+      dispatchSuccessShowMessage(dispatch, data);
+    })
+    .catch(error => {
+      dispatchErrorShowMessage(dispatch, message);
+    });
+};
+
+export const optOut = (token, type) => dispatch => {
+  const url = "/subscription/" + type + "/";
+
+  return deleteCalls("delete", url, token)
+    .then(data => {
+      dispatchSuccessShowMessage(dispatch, data);
+    })
+    .catch(error => {
+      dispatchErrorShowMessage(dispatch, message);
+    });
 };

--- a/src/redux/actions/profileActions/__tests__/profileActions.spec.js
+++ b/src/redux/actions/profileActions/__tests__/profileActions.spec.js
@@ -91,6 +91,7 @@ describe("saveProfileInfo fn", () => {
         });
       });
   });
+
   test("should call Showmessage with an error message if the operation failed", () => {
     axios.put.mockImplementation(() => Promise.reject({}));
     const store = storeFactory({

--- a/src/redux/actions/profileActions/profileActions.js
+++ b/src/redux/actions/profileActions/profileActions.js
@@ -2,6 +2,7 @@ import types from "../types";
 import { apiCalls } from "../../../Helpers/axios";
 import { isLoggedIn } from "../../../Helpers/authHelpers";
 import { ShowMessage } from "../SnackBarAction";
+
 const {
   LOADPROFILE,
   SETPROFILEDATA,
@@ -69,6 +70,7 @@ export const getProfile = (username, history) => dispatch => {
         type: SETOWNERSTATUS,
         payload: isUserOwner(profile)
       });
+      return profile;
     })
     .catch(({ response: { status, data } }) => {
       handleProfileErrors(status, data, dispatch, history);

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -1,5 +1,4 @@
 import { combineReducers } from "redux";
-
 import articles from "./ArticlesReducer";
 import MessageReducer from "./SnackBarReducer";
 import userProfile from "./userProfile/userProfile";

--- a/src/testutils/index.js
+++ b/src/testutils/index.js
@@ -40,6 +40,7 @@ export const rejectPromise = method => {
 
 export const snackBarError = (method, func, value) => {
   let store = storeFactory();
+
   rejectPromise(method);
 
   return store.dispatch(func()).then(() => {


### PR DESCRIPTION
#### Title
opt-in and out of notifications

#### Description

Users should have the ability to opt-in and out of (or turn on and off) notifications.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue) 

- [x] New feature (non-breaking change which adds functionality) 

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) 

### How can this be manually tested?

- Clone the repository  
  `git clone https://github.com/andela/ah-fortem-frontend.gi`

-  Check out to current branch
    `git checkout story/166980317-opt-in-out-notifications`

- setup npm
`$ npm install`

- run application
`$ npm run dev`

- View Profile and toggle between the notification settings to turn on/off notifications

![image](https://user-images.githubusercontent.com/11487123/61849005-98a9ef80-aeb8-11e9-9cf7-ef60a0df6e9f.png)

![image](https://user-images.githubusercontent.com/11487123/61849017-a2335780-aeb8-11e9-96fb-fdc02f012372.png)


#### How Has This Been Tested?
- [x] Unit tests

#### Checklist:
- [x] Opt-in and out of in-app notifications
- [x] Opt-in and out of email notifications
- [x] Display Notification settings on the profile page
- [x] Write unit tests

#### PT stories
[#166980317](https://www.pivotaltracker.com/story/show/166980317)